### PR TITLE
Add autoclose workflow to allow automatically closing issues without further activity

### DIFF
--- a/.github/workflows/autoclose-cancel.yml
+++ b/.github/workflows/autoclose-cancel.yml
@@ -1,0 +1,34 @@
+name: Cancel autoclose on new comment
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  cancel-autoclose:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Remove autoclose label if present
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Extract labels from payload (works for issue comments)
+            const issue = context.payload.issue || {};
+            const issueLabels = (issue.labels || []).map(l => l.name);
+            const autocloseLabels = issueLabels.filter(l => l.startsWith('autoclose-'));
+
+            if (autocloseLabels.length > 0) {
+              for (const label of autocloseLabels) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  });
+                } catch (err) {
+                  // ignore failures (label might already be gone)
+                }
+              }
+            }

--- a/.github/workflows/autoclose-check.yml
+++ b/.github/workflows/autoclose-check.yml
@@ -1,0 +1,54 @@
+name: Auto-close inactive issues
+on:
+  schedule:
+    - cron: '0 1 * * *'  # every day at 01:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close issues past autoclose period
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+
+            // Get all labels starting with 'autoclose-'
+            const labels = await github.paginate(github.rest.issues.listLabelsForRepo, { owner, repo });
+            const autocloseLabels = labels.filter(l => l.name.startsWith('autoclose-'));
+
+            for (const label of autocloseLabels) {
+              const match = label.name.match(/autoclose-(\d+)w/);
+              if (!match) continue;
+              const weeks = parseInt(match[1], 10);
+              const days = weeks * 7;
+              const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: 'open',
+                labels: label.name,
+              });
+
+              for (const issue of issues) {
+                const lastUpdated = new Date(issue.updated_at);
+                if (lastUpdated < cutoff) {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    body: `🔒 Closing this issue due to no feedback after ${weeks} week${weeks > 1 ? 's' : ''}. Feel free to reopen if needed.`
+                  });
+                  await github.rest.issues.update({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    state: 'closed'
+                  });
+                }
+              }
+            }

--- a/.github/workflows/autoclose-command.yml
+++ b/.github/workflows/autoclose-command.yml
@@ -1,0 +1,63 @@
+name: Handle /autoclose command
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  handle-command:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Parse /autoclose duration and compute close date
+        id: parse
+        run: |
+          set -euo pipefail
+          BODY="${{ github.event.comment.body }}"
+
+          # Find first occurrence of "/autoclose <number>w" anywhere in the comment
+          CMD=$(echo "$BODY" | grep -oE '/autoclose[[:space:]]*[0-9]+w' | head -n1 || true)
+
+          if [ -z "$CMD" ]; then
+            # No explicit /autoclose found -> mark as not found
+            echo "found=false" >> $GITHUB_OUTPUT
+            echo "weeks=" >> $GITHUB_OUTPUT
+            echo "close_date=" >> $GITHUB_OUTPUT
+            echo "plural=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          WEEKS=$(echo "$CMD" | grep -oE '[0-9]+' || true)
+          if [ -z "$WEEKS" ]; then
+            WEEKS=4
+          fi
+
+          # Compute closing date (friendly format, e.g., "Dec 17, 2025")
+          CLOSE_DATE=$(date -d "+${WEEKS} weeks" +'%b %d, %Y')
+
+          if [ "$WEEKS" -eq 1 ]; then
+            PLURAL=""
+          else
+            PLURAL="s"
+          fi
+
+          echo "found=true" >> $GITHUB_OUTPUT
+          echo "weeks=$WEEKS" >> $GITHUB_OUTPUT
+          echo "close_date=$CLOSE_DATE" >> $GITHUB_OUTPUT
+          echo "plural=$PLURAL" >> $GITHUB_OUTPUT
+
+      - name: Add confirmation comment with exact close date
+        if: steps.parse.outputs.found == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ⏳ Auto-close scheduled in **${{ steps.parse.outputs.weeks }} week${{ steps.parse.outputs.plural }}**.
+            This issue will be closed automatically on ${{ steps.parse.outputs.close_date }} if there is no further activity.
+
+      - name: Add autoclose label (weeks-based)
+        if: steps.parse.outputs.found == 'true'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: autoclose-${{ steps.parse.outputs.weeks }}w


### PR DESCRIPTION
The workflow will close all issues with a label "autoclose-<number>w" if the issue had no activity for <number> weeks after the last comment. The label can either be added manually by adding "/autoclose <number>w" anywhere in a comment, or by using the other ways to add a label. If just adding "/autoclose", i.e. without "<number>w", it will default to 4 weeks.