### PR TITLE
Fix autoclose workflow triggering on quoted /autoclose comments

### DIFF
--- a/.github/workflows/autoclose-cancel.yml
+++ b/.github/workflows/autoclose-cancel.yml
@@ -14,7 +14,9 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          if echo "$COMMENT_BODY" | grep -q '/autoclose'; then
+          # Strip blockquoted lines to avoid treating quoted /autoclose as a command
+          FILTERED_BODY=$(echo "$COMMENT_BODY" | grep -v '^[[:space:]]*>')
+          if echo "$FILTERED_BODY" | grep -q '/autoclose'; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/autoclose-command.yml
+++ b/.github/workflows/autoclose-command.yml
@@ -22,7 +22,15 @@ jobs:
           WEEKS=""
           # Case 1: Comment contains /autoclose
           if [[ "$EVENT_NAME" == "issue_comment" ]]; then
-            MATCH=$(echo "$COMMENT_BODY" | grep -oE '/autoclose([[:space:]]+[0-9]+w)?' | head -n1 || true)
+            # Only allow maintainers/collaborators to trigger /autoclose
+            AUTHOR_ASSOC="${{ github.event.comment.author_association }}"
+            if [[ "$AUTHOR_ASSOC" != "OWNER" && "$AUTHOR_ASSOC" != "COLLABORATOR" && "$AUTHOR_ASSOC" != "MEMBER" ]]; then
+              echo "found=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            # Strip blockquoted lines to avoid triggering on quoted /autoclose
+            FILTERED_BODY=$(echo "$COMMENT_BODY" | grep -v '^[[:space:]]*>')
+            MATCH=$(echo "$FILTERED_BODY" | grep -oE '/autoclose([[:space:]]+[0-9]+w)?' | head -n1 || true)
             if [[ -n "$MATCH" ]]; then
               FOUND=true
               WEEKS=$(echo "$MATCH" | grep -oE '[0-9]+' || true)


### PR DESCRIPTION
  Strip blockquoted lines before checking for /autoclose, and restrict
  the command to maintainers/collaborators only.