### PR TITLE
feat: "Force composition while streaming" toggle (fixes docked stretched/mis-scaled capture)

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,6 +46,24 @@ class Plugin:
             self.settingManager.setSetting("lastRunState", "stop")
         return res
 
+    async def setForceComposition(self, enabled):
+        """
+        Persist the "force gamescope composition while streaming" toggle. The
+        controller applies it on its next start_async and clears it on stop_async;
+        also apply immediately if Sunshine is already running. Fixes the docked
+        capture glitch where the image is squeezed into part of the screen with
+        the right side stretched across the rest.
+        """
+        self.settingManager.setSetting("forceComposition", enabled)
+        self.sunshineController.force_composition = enabled
+        if self.sunshineController.isSunshineRunning():
+            self.sunshineController.setCompositionForce(enabled)
+        decky.logger.info(f"forceComposition set to {enabled}")
+        return enabled
+
+    async def getForceComposition(self):
+        return self.settingManager.getSetting("forceComposition", False)
+
     async def stopSunshine(self):
         decky.logger.info("Stopping sunshine...")
         res = await self.sunshineController.stop_async()
@@ -139,6 +157,10 @@ class Plugin:
             else:
                 decky.logger.info("Setting auth header from settings")
                 self.sunshineController.authHeader = lastAuthHeader
+
+        # Carry the persisted "force composition while streaming" preference into
+        # the controller so the auto-start below (and any later start) applies it.
+        self.sunshineController.force_composition = self.settingManager.getSetting("forceComposition", False)
 
         lastRunState = self.settingManager.getSetting("lastRunState", "")
         if lastRunState in ("start", ""):

--- a/main.py
+++ b/main.py
@@ -56,8 +56,8 @@ class Plugin:
         """
         self.settingManager.setSetting("forceComposition", enabled)
         self.sunshineController.force_composition = enabled
-        if self.sunshineController.isSunshineRunning():
-            self.sunshineController.setCompositionForce(enabled)
+        if await self.sunshineController.isSunshineRunning_async():
+            await self.sunshineController.setCompositionForce_async(enabled)
         decky.logger.info(f"forceComposition set to {enabled}")
         return enabled
 

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -329,18 +329,48 @@ class SunshineController:
         It is applied on stream start and cleared on stop, so gamescope's
         power-saving direct scanout is only disabled while actually streaming.
 
-        Sunshine runs as root, so the atom must be set as the session user (`deck`)
+        Sunshine runs as root, so the atom must be set as the session user
         on DISPLAY :0.
         """
         value = "1" if enabled else "0"
+        username = self._getSessionUsername()
+        if not username:
+            self.logger.warning(f"No session user found for setting GAMESCOPE_COMPOSITE_FORCE={value}")
+            return False
         cmd = [
-            "su", "deck", "-c",
+            "su", username, "-c",
             "DISPLAY=:0 xprop -root -f GAMESCOPE_COMPOSITE_FORCE 32c "
             "-set GAMESCOPE_COMPOSITE_FORCE " + value,
         ]
         return self._run_and_check(
             cmd, context=f"setting GAMESCOPE_COMPOSITE_FORCE={value}"
         )
+
+    def _getSessionUsername(self) -> str | None:
+        """
+        Determine the user owning the gamescope session. On the Steam Deck this
+        is 'deck', but as in the audio socket discovery it must not be
+        hardcoded: other systems may use a different user, so fall back to the
+        owner of the first regular user's runtime directory.
+        :return: The username, or None if no regular user was found
+        """
+        try:
+            return pwd.getpwnam("deck").pw_name
+        except KeyError:
+            pass
+
+        # Sort numerically by UID for a reproducible search order, as in
+        # _expandSocketPattern
+        uid_matches = (re.match(r"^/run/user/(\d+)$", path) for path in glob.glob("/run/user/*"))
+        uids = sorted(int(match.group(1)) for match in uid_matches if match)
+        for uid in uids:
+            if uid < 1000:
+                continue
+            try:
+                return pwd.getpwuid(uid).pw_name
+            except KeyError:
+                continue
+        return None
 
     async def setCompositionForce_async(self, enabled: bool) -> bool:
         """

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -64,6 +64,12 @@ class SunshineController:
         assert logger is not None
         self.logger = logger
 
+        # Whether to force gamescope composition (vs direct scanout) while
+        # streaming. Applied at the end of start_async and cleared in stop_async,
+        # so every start/stop path is covered regardless of caller. See
+        # setCompositionForce() for the why.
+        self.force_composition = False
+
         sslContext = ssl.create_default_context()
         sslContext.check_hostname = False
         sslContext.verify_mode = ssl.CERT_NONE
@@ -192,6 +198,11 @@ class SunshineController:
         :return: True if Sunshine was started successfully or is already running, False otherwise
         """
         if await self.isSunshineRunning_async():
+            # Already running (e.g. it survived a plugin_loader restart via setsid):
+            # still (re)apply the composition override so the atom matches the setting.
+            if self.force_composition:
+                self.logger.info("Forcing gamescope composition for streaming")
+                self.setCompositionForce(True)
             return True
 
         retry_count = 60
@@ -263,6 +274,10 @@ class SunshineController:
             self.logger.info(f"Sunshine process not found yet. Checking again in {wait_time} {'second' if wait_time == 1 else 'seconds'}")
             await asyncio.sleep(wait_time)
 
+        if self.force_composition:
+            self.logger.info("Forcing gamescope composition for streaming")
+            self.setCompositionForce(True)
+
         return True
 
     async def stop_async(self) -> bool:
@@ -270,6 +285,10 @@ class SunshineController:
         Stop the Sunshine process.
         :return: True if Sunshine was stopped successfully or wasn't running, False otherwise
         """
+        # Always release the gamescope composition override when stopping, so the
+        # direct-scanout power optimization is restored once we're not streaming.
+        self.setCompositionForce(False)
+
         if not await self.isSunshineRunning_async():
             return True
 
@@ -287,6 +306,36 @@ class SunshineController:
             await asyncio.sleep(wait_time)
 
         return True
+
+    def setCompositionForce(self, enabled: bool) -> bool:
+        """
+        Force gamescope to always composite instead of using its direct-scanout
+        (single-plane) optimization, by setting the GAMESCOPE_COMPOSITE_FORCE
+        root-window atom on its XWayland display.
+
+        Why this exists: in Game Mode (embedded gamescope) the `--force-composition`
+        flag and gamescopectl convars are ignored — root-window atoms override them.
+        When gamescope drops to direct scanout of a smaller buffer (e.g. when the
+        mouse cursor auto-hides), Sunshine's KMS capture streams that stretched and
+        mis-scaled — most visibly when docked, where the image is squeezed into part
+        of the external screen with the right side stretched across the rest.
+        Forcing composition keeps the captured geometry consistent.
+
+        It is applied on stream start and cleared on stop, so gamescope's
+        power-saving direct scanout is only disabled while actually streaming.
+
+        Sunshine runs as root, so the atom must be set as the session user (`deck`)
+        on DISPLAY :0.
+        """
+        value = "1" if enabled else "0"
+        cmd = [
+            "su", "deck", "-c",
+            "DISPLAY=:0 xprop -root -f GAMESCOPE_COMPOSITE_FORCE 32c "
+            "-set GAMESCOPE_COMPOSITE_FORCE " + value,
+        ]
+        return self._run_and_check(
+            cmd, context=f"setting GAMESCOPE_COMPOSITE_FORCE={value}"
+        )
 
     async def pair_async(self, pin, client_name) -> bool:
         """

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -202,7 +202,7 @@ class SunshineController:
             # still (re)apply the composition override so the atom matches the setting.
             if self.force_composition:
                 self.logger.info("Forcing gamescope composition for streaming")
-                self.setCompositionForce(True)
+                await self.setCompositionForce_async(True)
             return True
 
         retry_count = 60
@@ -276,7 +276,7 @@ class SunshineController:
 
         if self.force_composition:
             self.logger.info("Forcing gamescope composition for streaming")
-            self.setCompositionForce(True)
+            await self.setCompositionForce_async(True)
 
         return True
 
@@ -285,9 +285,14 @@ class SunshineController:
         Stop the Sunshine process.
         :return: True if Sunshine was stopped successfully or wasn't running, False otherwise
         """
-        # Always release the gamescope composition override when stopping, so the
+        # Release the gamescope composition override when stopping, so the
         # direct-scanout power optimization is restored once we're not streaming.
-        self.setCompositionForce(False)
+        # Only when the override is active: otherwise every stop would spawn a
+        # su/xprop subprocess (and log an error on systems where that fails)
+        # even though the feature was never enabled. Disabling the toggle while
+        # Sunshine is running is already handled live in setForceComposition.
+        if self.force_composition:
+            await self.setCompositionForce_async(False)
 
         if not await self.isSunshineRunning_async():
             return True
@@ -336,6 +341,12 @@ class SunshineController:
         return self._run_and_check(
             cmd, context=f"setting GAMESCOPE_COMPOSITE_FORCE={value}"
         )
+
+    async def setCompositionForce_async(self, enabled: bool) -> bool:
+        """
+        Async variant of setCompositionForce that doesn't block the event loop.
+        """
+        return await self._to_thread(lambda: self.setCompositionForce(enabled))
 
     async def pair_async(self, pin, client_name) -> bool:
         """

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -70,6 +70,10 @@ class SunshineController:
         # setCompositionForce() for the why.
         self.force_composition = False
 
+        # Watcher task re-asserting the composition override after boot,
+        # see _applyCompositionForce()
+        self._composition_watch_task = None
+
         sslContext = ssl.create_default_context()
         sslContext.check_hostname = False
         sslContext.verify_mode = ssl.CERT_NONE
@@ -202,7 +206,7 @@ class SunshineController:
             # still (re)apply the composition override so the atom matches the setting.
             if self.force_composition:
                 self.logger.info("Forcing gamescope composition for streaming")
-                await self.setCompositionForce_async(True)
+                await self._applyCompositionForce()
             return True
 
         retry_count = 60
@@ -276,7 +280,7 @@ class SunshineController:
 
         if self.force_composition:
             self.logger.info("Forcing gamescope composition for streaming")
-            await self.setCompositionForce_async(True)
+            await self._applyCompositionForce()
 
         return True
 
@@ -285,6 +289,16 @@ class SunshineController:
         Stop the Sunshine process.
         :return: True if Sunshine was stopped successfully or wasn't running, False otherwise
         """
+        # Stop the watcher before releasing the override, so it cannot
+        # re-assert the old value concurrently to the release below.
+        if self._composition_watch_task is not None:
+            self._composition_watch_task.cancel()
+            try:
+                await self._composition_watch_task
+            except asyncio.CancelledError:
+                pass
+            self._composition_watch_task = None
+
         # Release the gamescope composition override when stopping, so the
         # direct-scanout power optimization is restored once we're not streaming.
         # Only when the override is active: otherwise every stop would spawn a
@@ -377,6 +391,51 @@ class SunshineController:
         Async variant of setCompositionForce that doesn't block the event loop.
         """
         return await self._to_thread(lambda: self.setCompositionForce(enabled))
+
+    async def _applyCompositionForce(self) -> None:
+        """
+        Apply the composition override and watch it for a bounded window.
+        On a cold boot the plugin can win the race against gamescope's own
+        session initialization, which (re)creates the GAMESCOPE_COMPOSITE_FORCE
+        atom with value 0 and thereby undoes an earlier write. A single write
+        is therefore not trustworthy shortly after boot; re-check the atom for
+        a while and re-assert it if it was reset.
+        """
+        await self.setCompositionForce_async(True)
+        if self._composition_watch_task is None or self._composition_watch_task.done():
+            loop = asyncio.get_event_loop()
+            self._composition_watch_task = loop.create_task(self._watchCompositionForce())
+
+    async def _watchCompositionForce(self) -> None:
+        # 12 checks every 10 seconds: covers the window between the plugin
+        # applying the override early in the boot process and the gamescope
+        # session finishing its initialization.
+        for _ in range(12):
+            await asyncio.sleep(10)
+            if not self.force_composition or not await self.isSunshineRunning_async():
+                return
+            value = await self._to_thread(self._getCompositionForce)
+            if value is not None and value != 1:
+                self.logger.info("GAMESCOPE_COMPOSITE_FORCE was reset (likely by gamescope session initialization) - re-asserting")
+                await self.setCompositionForce_async(True)
+
+    def _getCompositionForce(self) -> int | None:
+        """
+        Read the current value of the GAMESCOPE_COMPOSITE_FORCE atom.
+        :return: The value, 0 if the atom does not exist, or None if it could not be read
+        """
+        username = self._getSessionUsername()
+        if not username:
+            return None
+        result = self._run_and_capture_stdout(
+            ["su", username, "-c", "DISPLAY=:0 xprop -root GAMESCOPE_COMPOSITE_FORCE"],
+            context="reading GAMESCOPE_COMPOSITE_FORCE"
+        )
+        if result is None:
+            return None
+        value_match = re.search(r"=\s*(\d+)", result)
+        # A missing atom means gamescope (re)started without the override
+        return int(value_match.group(1)) if value_match else 0
 
     async def pair_async(self, pin, client_name) -> bool:
         """

--- a/src/components/LabelWithInfo.tsx
+++ b/src/components/LabelWithInfo.tsx
@@ -1,0 +1,77 @@
+import { VFC, useState, useRef } from 'react'
+import { Focusable } from "decky-frontend-lib";
+import { FaInfoCircle } from "react-icons/fa";
+
+/**
+ * A field label with a small, focusable (i) button next to it. Pressing it
+ * toggles the field's help text on and off, so settings rows can stay compact
+ * instead of carrying long inline descriptions.
+ *
+ * A bare Focusable doesn't get Steam's default focus ring, so we track focus
+ * ourselves and visibly highlight the button when it's selected.
+ */
+export const LabelWithInfo: VFC<{
+    title: string;
+    onToggleHelp: () => void;
+}> = ({ title, onToggleHelp }) => {
+    const [focused, setFocused] = useState(false);
+    const lastToggleRef = useRef(0);
+    const suppressFocusUntilRef = useRef(0);
+
+    // A Focusable can deliver both onActivate and onClick for a single press, which
+    // would toggle the help text right back off. Stop propagation (so we never
+    // toggle the parent field) and de-dupe presses that land within the same
+    // interaction.
+    const toggle = (e?: any) => {
+        e?.stopPropagation?.();
+        const now = performance.now();
+        if (now - lastToggleRef.current < 300) return;
+        lastToggleRef.current = now;
+        onToggleHelp();
+    };
+
+    // Touch input focuses the button and leaves it focused (the Deck fires the
+    // gamepad focus events for touch as well), which would leave the highlight
+    // stuck after a tap. Touch is detectable via DOM touch events though: drop
+    // the highlight on touch and suppress the focus events arriving with the
+    // same tap. Gamepad navigation fires no touch events, so a controller
+    // keeps the highlight while the button is focused.
+    const onTouch = () => {
+        suppressFocusUntilRef.current = performance.now() + 500;
+        setFocused(false);
+    };
+
+    return (
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span>{title}</span>
+            <Focusable
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    cursor: "pointer",
+                    width: 26,
+                    height: 26,
+                    borderRadius: "50%",
+                    transition: "background 0.12s ease, transform 0.12s ease",
+                    background: focused ? "rgba(255, 255, 255, 0.25)" : "transparent",
+                    boxShadow: focused ? "0 0 0 2px rgba(255, 255, 255, 0.7)" : "none",
+                    transform: focused ? "scale(1.1)" : "scale(1)",
+                }}
+                onActivate={toggle}
+                onClick={toggle}
+                onTouchEnd={onTouch}
+                // Deliberately no DOM onFocus/onBlur: the highlight only exists
+                // for gamepad navigation, see onTouch above.
+                onGamepadFocus={() => {
+                    if (performance.now() < suppressFocusUntilRef.current) return;
+                    setFocused(true);
+                }}
+                onGamepadBlur={() => setFocused(false)}
+                onOKActionDescription="Toggle help"
+            >
+                <FaInfoCircle style={{ opacity: focused ? 1 : 0.6 }} />
+            </Focusable>
+        </div>
+    );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import {
   PanelSection,
   PanelSectionRow,
   ButtonItem,
+  ToggleField,
   Spinner,
   showModal,
 } from "decky-frontend-lib";
@@ -31,6 +32,7 @@ const Content: VFC = () => {
   const [credentials, setCredentials] = useState<{username: string, password: string} | null>(null);
   const [isGettingCredentials, setIsGettingCredentials] = useState<boolean>(false);
   const [getCredentialsReturnedValue, setGetCredentialsReturnedValue] = useState<boolean | null>(null);
+  const [forceComposition, setForceComposition] = useState<boolean>(false);
 
   const updateSunshineState = async () => {
     const isSunshineRunning = await backend.isSunshineRunning();
@@ -50,6 +52,10 @@ const Content: VFC = () => {
 
   useEffect(() => {
     refreshVersionInfo(false);
+  }, []);
+
+  useEffect(() => {
+    backend.getForceComposition().then(setForceComposition);
   }, []);
 
   useEffect(() => {
@@ -209,6 +215,19 @@ const Content: VFC = () => {
           >
             Pair Client
           </ButtonItem>
+      </PanelSectionRow>
+
+      {/* Streaming fix: force gamescope composition (docked stretched capture) */}
+      <PanelSectionRow>
+        <ToggleField
+          label="Fix stretched image when docked"
+          description="Fixes the docked glitch where the picture is squeezed into part of the screen with the right side stretched across the rest. Might impact performance."
+          checked={forceComposition}
+          onChange={(value: boolean) => {
+            setForceComposition(value);
+            backend.setForceComposition(value);
+          }}
+        />
       </PanelSectionRow>
 
       {/* Update Section */}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import backend from "./util/backend";
 
 import { PairingModal } from "./components/PairingModal";
 import { CredentialsModal } from "./components/CredentialsModal";
+import { LabelWithInfo } from "./components/LabelWithInfo";
 import { LOG_TAG } from "./util/constants";
 
 const Content: VFC = () => {
@@ -33,6 +34,7 @@ const Content: VFC = () => {
   const [isGettingCredentials, setIsGettingCredentials] = useState<boolean>(false);
   const [getCredentialsReturnedValue, setGetCredentialsReturnedValue] = useState<boolean | null>(null);
   const [forceComposition, setForceComposition] = useState<boolean>(false);
+  const [showCompositionHelp, setShowCompositionHelp] = useState<boolean>(false);
 
   const updateSunshineState = async () => {
     const isSunshineRunning = await backend.isSunshineRunning();
@@ -220,8 +222,10 @@ const Content: VFC = () => {
       {/* Streaming fix: force gamescope composition (docked stretched capture) */}
       <PanelSectionRow>
         <ToggleField
-          label="Fix stretched image when docked"
-          description="Fixes the docked glitch where the picture is squeezed into part of the screen with the right side stretched across the rest. Might impact performance."
+          label={<LabelWithInfo title="Fix image when docked" onToggleHelp={() => setShowCompositionHelp(value => !value)} />}
+          description={showCompositionHelp
+            ? "Fixes the stream being squeezed into part of the screen while docked. May slightly increase GPU load while Sunshine is running."
+            : undefined}
           checked={forceComposition}
           onChange={(value: boolean) => {
             setForceComposition(value);

--- a/src/util/backend.tsx
+++ b/src/util/backend.tsx
@@ -61,6 +61,16 @@ class Backend {
         return result === true;
     }
 
+    public getForceComposition = async (): Promise<boolean> => {
+        const result = await this.call<boolean>("getForceComposition");
+        return result === true;
+    }
+
+    public setForceComposition = async (enabled: boolean): Promise<boolean> => {
+        const result = await this.call<{ enabled: boolean }, boolean>("setForceComposition", { enabled });
+        return result === true;
+    }
+
     private call<TRes>(method: string): Promise<TRes | null>;
     private call<TArgs, TRes>(method: string, args: TArgs): Promise<TRes | null>;
     private async call(method: string, args?: unknown): Promise<unknown | null>{


### PR DESCRIPTION
## What & why

Adds an opt-in **"Force composition while streaming"** toggle that fixes a **docked** capture glitch: while docked and streaming, the picture gets squeezed into a small portion of the external display and the right side is stretched across the remaining resolution.

### Root cause
In Game Mode the Deck runs an **embedded gamescope** compositor. When it drops to its **direct-scanout / single-plane** path (for example when the mouse cursor auto-hides), it scans out a *smaller* buffer directly. Sunshine's `kms` capture then grabs that buffer and streams it stretched / mis-scaled.

The usual fixes don't work here: in **embedded** gamescope the `--force-composition` launch flag and the `gamescopectl`/convar overrides are ignored. The only knob that actually takes effect is the **`GAMESCOPE_COMPOSITE_FORCE` root-window atom** on XWayland `:0`.

### The fix
While a stream session is active, set that atom so gamescope always composites the full frame, keeping captured geometry correct. Because Sunshine runs as root, the atom is set as the session user:

```
su deck -c 'DISPLAY=:0 xprop -root -f GAMESCOPE_COMPOSITE_FORCE 32c -set GAMESCOPE_COMPOSITE_FORCE 1'
```

It is **cleared on stop**, so gamescope's direct-scanout path is only disabled while actually streaming.

The override lives on `SunshineController` (`force_composition` flag, applied at the end of `start_async`, also re-applied on the already-running early-return path, and cleared in `stop_async`). That means it's honored on **every** start path — including the `_main` auto-start that restores the last run state — not just the UI "Start" button.

### UI
A `ToggleField` (persisted via the existing settings manager), default off, whose description explains the fix and the trade-off.

## Trade-off
Forcing composition disables gamescope's direct-scanout optimization while a stream is active, so there is some additional GPU/compositor work versus direct scanout. In testing on a Steam Deck OLED (Van Gogh) the impact was acceptable — the stream stayed smooth with the toggle on and the geometry stayed correct. It is **opt-in and default off**, and cleared automatically on stop, so it never costs anything when not streaming.

## Notes
- No new dependencies; `xprop` is already present in the SteamOS session.
- The atom is a gamescope runtime root-window atom, applied/cleared live (no gamescope or Sunshine restart needed).

## Relation to #17
This *may* be related to #17 ("Stuck in Portrait Orientation while streaming in desktop mode") — both could stem from gamescope's direct-scanout path mangling capture geometry — but I have **not** verified that it resolves that desktop-mode rotation case. So this PR deliberately does **not** claim to close #17; it targets the docked stretched/mis-scaled capture described above.

## Testing
On a Steam Deck OLED (SteamOS 3.8, Game Mode), `encoder=vaapi`, `h264_vaapi` hardware path:
- Enable + start streaming → `GAMESCOPE_COMPOSITE_FORCE` reads `1`; the docked stretch no longer occurs and the stream stays smooth.
- Disable / stop → atom returns to `0`; without the toggle the capture goes back to stretched.
- Restart `plugin_loader` with the setting on and Sunshine auto-starting → journal logs `Forcing gamescope composition for streaming` and the atom is `1` (the path that previously bypassed the hook).
