### PR TITLE
feat: add video encoder dropdown (VAAPI / Vulkan / Software / Auto)

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,6 +46,23 @@ class Plugin:
             self.settingManager.setSetting("lastRunState", "stop")
         return res
 
+    async def getEncoder(self):
+        return self.sunshineController.getEncoder()
+
+    async def setEncoder(self, encoder):
+        """
+        Persist the Sunshine video encoder selection. Sunshine only reads its config
+        at launch, so if it's currently running we restart it to apply the change.
+        Returns the encoder that is now in effect (so the UI can confirm / revert).
+        """
+        if not self.sunshineController.setEncoder(encoder):
+            return self.sunshineController.getEncoder()
+        if self.sunshineController.isSunshineRunning():
+            decky.logger.info("Restarting Sunshine to apply encoder change")
+            await self.sunshineController.stop_async()
+            await self.sunshineController.start_async()
+        return self.sunshineController.getEncoder()
+
     async def stopSunshine(self):
         decky.logger.info("Stopping sunshine...")
         res = await self.sunshineController.stop_async()

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -266,6 +266,90 @@ class SunshineController:
 
         return True
 
+    # Encoders selectable from the UI. "" means "let Sunshine auto-detect".
+    VALID_ENCODERS = ("", "vaapi", "vulkan", "software")
+
+    @property
+    def configPath(self) -> str:
+        """
+        Path to the sunshine.conf the *streaming* Sunshine actually reads. Sunshine
+        is launched as a flatpak with this controller's environment, so it resolves
+        its config under that env's HOME (root, in practice) — deriving the path the
+        same way guarantees we edit the file the running process loads, not the
+        deck-user copy.
+        """
+        home = self.environment_variables.get("HOME") or "/root"
+        return os.path.join(home, ".var", "app", self.SunshineFlatpakAppId,
+                            "config", "sunshine", "sunshine.conf")
+
+    def _set_config_value(self, key: str, value: str | None) -> bool:
+        """
+        Update a single 'key = value' line in sunshine.conf, preserving every other
+        line (comments, hevc_mode, etc.). value=None removes the key entirely.
+        """
+        try:
+            try:
+                with open(self.configPath, "r") as f:
+                    lines = f.readlines()
+            except FileNotFoundError:
+                os.makedirs(os.path.dirname(self.configPath), exist_ok=True)
+                lines = []
+
+            new_lines = []
+            replaced = False
+            for line in lines:
+                stripped = line.strip()
+                if stripped and not stripped.startswith("#") and "=" in stripped \
+                        and stripped.split("=", 1)[0].strip() == key:
+                    if value is not None and not replaced:
+                        new_lines.append(f"{key} = {value}\n")
+                    replaced = True
+                    continue
+                new_lines.append(line)
+
+            if value is not None and not replaced:
+                if new_lines and not new_lines[-1].endswith("\n"):
+                    new_lines[-1] += "\n"
+                new_lines.append(f"{key} = {value}\n")
+
+            with open(self.configPath, "w") as f:
+                f.writelines(new_lines)
+            return True
+        except Exception as e:
+            self.logger.exception(f"Could not set Sunshine config '{key}'", exc_info=e)
+            return False
+
+    def getEncoder(self) -> str:
+        """Return the configured encoder, or "" if unset (auto-detect)."""
+        try:
+            with open(self.configPath, "r") as f:
+                for line in f:
+                    stripped = line.strip()
+                    if stripped.startswith("#") or "=" not in stripped:
+                        continue
+                    key, _, value = stripped.partition("=")
+                    if key.strip() == "encoder":
+                        return value.strip()
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            self.logger.exception("Could not read Sunshine encoder", exc_info=e)
+        return ""
+
+    def setEncoder(self, encoder: str) -> bool:
+        """
+        Write the encoder selection to sunshine.conf. "" / "auto" removes the key so
+        Sunshine auto-detects. Takes effect on Sunshine's next start.
+        """
+        encoder = (encoder or "").strip().lower()
+        if encoder == "auto":
+            encoder = ""
+        if encoder not in self.VALID_ENCODERS:
+            self.logger.error(f"Refusing to set unknown encoder '{encoder}'")
+            return False
+        self.logger.info(f"Setting Sunshine encoder to '{encoder or 'auto'}'")
+        return self._set_config_value("encoder", encoder or None)
+
     async def pair_async(self, pin, client_name) -> bool:
         """
         Send a PIN and client name to the Sunshine server.

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -1,0 +1,22 @@
+import { VFC } from 'react'
+import { ModalRoot } from "decky-frontend-lib";
+
+/**
+ * A minimal read-only modal that shows a title and a block of explanatory text.
+ * Used by the little (i) help buttons next to settings so the panel itself can
+ * stay compact instead of carrying long inline descriptions.
+ */
+export const InfoModal: VFC<{
+    closeModal?: () => void;
+    title: string;
+    body: string;
+}> = ({ closeModal, title, body }) => {
+    return (
+        <ModalRoot onCancel={closeModal} onEscKeypress={closeModal}>
+            <h2 style={{ margin: "0 0 0.5em 0" }}>{title}</h2>
+            <div style={{ whiteSpace: "pre-wrap", lineHeight: 1.4, opacity: 0.9 }}>
+                {body}
+            </div>
+        </ModalRoot>
+    );
+};

--- a/src/components/LabelWithInfo.tsx
+++ b/src/components/LabelWithInfo.tsx
@@ -1,4 +1,4 @@
-import { VFC, useState } from 'react'
+import { VFC, useState, useRef } from 'react'
 import { Focusable, showModal } from "decky-frontend-lib";
 import { FaInfoCircle } from "react-icons/fa";
 import { InfoModal } from "./InfoModal";
@@ -16,7 +16,18 @@ export const LabelWithInfo: VFC<{
     help: string;
 }> = ({ title, help }) => {
     const [focused, setFocused] = useState(false);
-    const open = () => showModal(<InfoModal title={title} body={help} />);
+    const lastOpenRef = useRef(0);
+
+    // A Focusable can deliver both onActivate and onClick for a single press, which
+    // would stack two identical modals. Stop propagation (so we never toggle the
+    // parent field) and de-dupe opens that land within the same interaction.
+    const open = (e?: any) => {
+        e?.stopPropagation?.();
+        const now = performance.now();
+        if (now - lastOpenRef.current < 300) return;
+        lastOpenRef.current = now;
+        showModal(<InfoModal title={title} body={help} />);
+    };
 
     return (
         <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
@@ -36,7 +47,7 @@ export const LabelWithInfo: VFC<{
                     transform: focused ? "scale(1.1)" : "scale(1)",
                 }}
                 onActivate={open}
-                onClick={(e: any) => { e?.stopPropagation?.(); open(); }}
+                onClick={open}
                 onFocus={() => setFocused(true)}
                 onBlur={() => setFocused(false)}
                 onGamepadFocus={() => setFocused(true)}

--- a/src/components/LabelWithInfo.tsx
+++ b/src/components/LabelWithInfo.tsx
@@ -1,0 +1,50 @@
+import { VFC, useState } from 'react'
+import { Focusable, showModal } from "decky-frontend-lib";
+import { FaInfoCircle } from "react-icons/fa";
+import { InfoModal } from "./InfoModal";
+
+/**
+ * A field label with a small, focusable (i) button next to it. Pressing it opens
+ * an InfoModal with the full explanation, so settings rows can stay compact
+ * instead of carrying long inline descriptions.
+ *
+ * A bare Focusable doesn't get Steam's default focus ring, so we track focus
+ * ourselves and visibly highlight the button when it's selected.
+ */
+export const LabelWithInfo: VFC<{
+    title: string;
+    help: string;
+}> = ({ title, help }) => {
+    const [focused, setFocused] = useState(false);
+    const open = () => showModal(<InfoModal title={title} body={help} />);
+
+    return (
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span>{title}</span>
+            <Focusable
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    cursor: "pointer",
+                    width: 26,
+                    height: 26,
+                    borderRadius: "50%",
+                    transition: "background 0.12s ease, transform 0.12s ease",
+                    background: focused ? "rgba(255, 255, 255, 0.25)" : "transparent",
+                    boxShadow: focused ? "0 0 0 2px rgba(255, 255, 255, 0.7)" : "none",
+                    transform: focused ? "scale(1.1)" : "scale(1)",
+                }}
+                onActivate={open}
+                onClick={(e: any) => { e?.stopPropagation?.(); open(); }}
+                onFocus={() => setFocused(true)}
+                onBlur={() => setFocused(false)}
+                onGamepadFocus={() => setFocused(true)}
+                onGamepadBlur={() => setFocused(false)}
+                onOKActionDescription="Show help"
+            >
+                <FaInfoCircle style={{ opacity: focused ? 1 : 0.6 }} />
+            </Focusable>
+        </div>
+    );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import backend from "./util/backend";
 
 import { PairingModal } from "./components/PairingModal";
 import { CredentialsModal } from "./components/CredentialsModal";
+import { LabelWithInfo } from "./components/LabelWithInfo";
 import { LOG_TAG } from "./util/constants";
 
 const Content: VFC = () => {
@@ -240,51 +241,6 @@ const Content: VFC = () => {
           </ButtonItem>
       </PanelSectionRow>
 
-      {/* Update Section */}
-      <PanelSectionRow>
-        <div style={{ display: "contents" }}>
-          <span>Installed Sunshine version: {isRefreshingVersionInfo ? "Checking..." : sunshineCurrentVersion || "Unknown"}</span>
-          {isRefreshingVersionInfo && <Spinner style={{ width: 14, height: 14, marginLeft: 8 }} />}
-          <br />
-          {sunshineUpdateVersion
-            ? <div style={{ display: "contents" }}>
-                <span style={{ color: "orange" }}>
-                  Available Sunshine version: {sunshineUpdateVersion} {(sunshineCurrentVersion === sunshineUpdateVersion && "(Rebuild)")}
-                </span>
-                <ButtonItem
-                  disabled={isStartingOrStopping || isUpdating}
-                  onClick={async () => {
-                    setIsUpdating(true);
-                    const success = await backend.updateSunshine();
-                    setIsUpdating(false);
-                    if (success) {
-                      setSunshineUpdateVersion(null);
-                      setUpdateCheckTriggeredManually(false);
-                    }
-                    updateSunshineState();
-                  }}
-                >
-                  Update
-                </ButtonItem>
-              </div>
-           : <div style={{ display: "contents" }}>
-                {updateCheckTriggeredManually && sunshineUpdateVersion == null && (
-                  <span>No update available</span>
-                )}
-                <ButtonItem
-                  disabled={isRefreshingVersionInfo}
-                  onClick={async () => {
-                    setUpdateCheckTriggeredManually(true);
-                    await refreshVersionInfo();
-                  }}
-                >
-                  Check for Sunshine update
-                </ButtonItem>
-              </div>
-          }
-        </div>
-      </PanelSectionRow>
-
       {/* Credentials Section */}
       <PanelSectionRow>
         <div style={{ display: "contents" }}>
@@ -328,8 +284,10 @@ const Content: VFC = () => {
       {/* Encoder selection */}
       <PanelSectionRow>
         <DropdownItem
-          label="Video encoder"
-          description="Which path Sunshine uses to encode the stream. VAAPI is the stable AMD hardware path on the Deck; Vulkan can be faster but tends to hit more bugs across different resolution / docking combinations on Steam Deck hardware and software; Software is CPU-only (highest latency). Auto lets Sunshine choose. Changing this restarts Sunshine, so an active stream will briefly drop."
+          label={<LabelWithInfo
+            title="Video encoder"
+            help={"Which path Sunshine uses to encode the stream.\n\nVAAPI: the stable AMD hardware path on the Deck (recommended).\n\nVulkan: can be faster, but tends to hit more bugs across different resolution / docking combinations on Steam Deck hardware and software.\n\nSoftware: CPU-only (highest latency).\n\nAuto: let Sunshine choose.\n\nChanging this restarts Sunshine, so an active stream will briefly drop."}
+          />}
           rgOptions={[
             { data: "", label: "Auto" },
             { data: "vaapi", label: "VAAPI (recommended)" },
@@ -343,6 +301,51 @@ const Content: VFC = () => {
             backend.setEncoder(option.data).then(setEncoder);
           }}
         />
+      </PanelSectionRow>
+
+      {/* Update Section */}
+      <PanelSectionRow>
+        <div style={{ display: "contents" }}>
+          <span>Installed Sunshine version: {isRefreshingVersionInfo ? "Checking..." : sunshineCurrentVersion || "Unknown"}</span>
+          {isRefreshingVersionInfo && <Spinner style={{ width: 14, height: 14, marginLeft: 8 }} />}
+          <br />
+          {sunshineUpdateVersion
+            ? <div style={{ display: "contents" }}>
+                <span style={{ color: "orange" }}>
+                  Available Sunshine version: {sunshineUpdateVersion} {(sunshineCurrentVersion === sunshineUpdateVersion && "(Rebuild)")}
+                </span>
+                <ButtonItem
+                  disabled={isStartingOrStopping || isUpdating}
+                  onClick={async () => {
+                    setIsUpdating(true);
+                    const success = await backend.updateSunshine();
+                    setIsUpdating(false);
+                    if (success) {
+                      setSunshineUpdateVersion(null);
+                      setUpdateCheckTriggeredManually(false);
+                    }
+                    updateSunshineState();
+                  }}
+                >
+                  Update
+                </ButtonItem>
+              </div>
+           : <div style={{ display: "contents" }}>
+                {updateCheckTriggeredManually && sunshineUpdateVersion == null && (
+                  <span>No update available</span>
+                )}
+                <ButtonItem
+                  disabled={isRefreshingVersionInfo}
+                  onClick={async () => {
+                    setUpdateCheckTriggeredManually(true);
+                    await refreshVersionInfo();
+                  }}
+                >
+                  Check for Sunshine update
+                </ButtonItem>
+              </div>
+          }
+        </div>
       </PanelSectionRow>
     </PanelSection>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import {
   PanelSection,
   PanelSectionRow,
   ButtonItem,
+  DropdownItem,
   Spinner,
   showModal,
 } from "decky-frontend-lib";
@@ -31,6 +32,7 @@ const Content: VFC = () => {
   const [credentials, setCredentials] = useState<{username: string, password: string} | null>(null);
   const [isGettingCredentials, setIsGettingCredentials] = useState<boolean>(false);
   const [getCredentialsReturnedValue, setGetCredentialsReturnedValue] = useState<boolean | null>(null);
+  const [encoder, setEncoder] = useState<string>("");
 
   const updateSunshineState = async () => {
     const isSunshineRunning = await backend.isSunshineRunning();
@@ -65,6 +67,10 @@ const Content: VFC = () => {
 
   useEffect(() => {
     refreshVersionInfo();
+  }, []);
+
+  useEffect(() => {
+    backend.getEncoder().then(setEncoder);
   }, []);
 
   useEffect(() => {
@@ -317,6 +323,26 @@ const Content: VFC = () => {
                 </ButtonItem>
             }
           </div>
+      </PanelSectionRow>
+
+      {/* Encoder selection */}
+      <PanelSectionRow>
+        <DropdownItem
+          label="Video encoder"
+          description="Which path Sunshine uses to encode the stream. VAAPI is the stable AMD hardware path on the Deck; Vulkan can be faster but is buggy on this GPU; Software is CPU-only (highest latency). Auto lets Sunshine choose. Changing this restarts Sunshine, so an active stream will briefly drop."
+          rgOptions={[
+            { data: "", label: "Auto" },
+            { data: "vaapi", label: "VAAPI (recommended)" },
+            { data: "vulkan", label: "Vulkan" },
+            { data: "software", label: "Software (CPU)" },
+          ]}
+          selectedOption={encoder}
+          disabled={isBusy}
+          onChange={(option: { data: string }) => {
+            setEncoder(option.data);
+            backend.setEncoder(option.data).then(setEncoder);
+          }}
+        />
       </PanelSectionRow>
     </PanelSection>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -329,7 +329,7 @@ const Content: VFC = () => {
       <PanelSectionRow>
         <DropdownItem
           label="Video encoder"
-          description="Which path Sunshine uses to encode the stream. VAAPI is the stable AMD hardware path on the Deck; Vulkan can be faster but is buggy on this GPU; Software is CPU-only (highest latency). Auto lets Sunshine choose. Changing this restarts Sunshine, so an active stream will briefly drop."
+          description="Which path Sunshine uses to encode the stream. VAAPI is the stable AMD hardware path on the Deck; Vulkan can be faster but tends to hit more bugs across different resolution / docking combinations on Steam Deck hardware and software; Software is CPU-only (highest latency). Auto lets Sunshine choose. Changing this restarts Sunshine, so an active stream will briefly drop."
           rgOptions={[
             { data: "", label: "Auto" },
             { data: "vaapi", label: "VAAPI (recommended)" },

--- a/src/util/backend.tsx
+++ b/src/util/backend.tsx
@@ -58,6 +58,16 @@ class Backend {
         return result === true;
     }
 
+    public getEncoder = async (): Promise<string> => {
+        const result = await this.call<string>("getEncoder");
+        return result ?? "";
+    }
+
+    public setEncoder = async (encoder: string): Promise<string> => {
+        const result = await this.call<{ encoder: string }, string>("setEncoder", { encoder });
+        return result ?? "";
+    }
+
     private call<TRes>(method: string): Promise<TRes | null>;
     private call<TArgs, TRes>(method: string, args: TArgs): Promise<TRes | null>;
     private async call(method: string, args?: unknown): Promise<unknown | null>{


### PR DESCRIPTION
## What & why

Adds a **Video encoder** dropdown to the plugin UI so users can choose which path Sunshine uses to encode the stream — without hand-editing `sunshine.conf`.

This matters on the Steam Deck specifically: on the Van Gogh APU the **RADV Vulkan encoder produces corrupt bitstreams** (visible corruption bands on motion), while **VAAPI (radeonsi / VCN)** is the stable hardware path. Today switching between them means digging into the root-owned flatpak config; this makes it a one-tap choice and explains the trade-off inline.

## Options
- **Auto** — unset; let Sunshine auto-detect.
- **VAAPI (recommended)** — stable AMD hardware path on the Deck.
- **Vulkan** — can be faster, but buggy on this GPU.
- **Software (CPU)** — no hardware accel, highest latency.

## How it works
- `SunshineController` gains:
  - `configPath` — derived from the **launch environment's `HOME`**, so it edits the *exact* `sunshine.conf` the root-launched flatpak actually reads (not the deck-user copy).
  - `_set_config_value()` — a line-preserving writer that updates just the `encoder` line and leaves everything else (comments, `hevc_mode`, …) untouched; `None` removes the key.
  - `getEncoder()` / `setEncoder()` — `""`/`auto` removes the key so Sunshine auto-detects; unknown values are rejected.
- `Plugin.setEncoder()` writes the config and, since Sunshine only reads its config **at launch**, restarts Sunshine when it's running so the change takes effect. It returns the encoder now in effect so the UI can confirm.
- Frontend adds a `DropdownItem` that loads the current value on open and notes that changing it restarts Sunshine.

## Notes
- No new dependencies.
- Default behavior unchanged: the dropdown simply reflects whatever `encoder` is already in the config (or Auto if unset).
- Independent of #95 — touches different code paths and can merge on its own.

## Testing
On a Steam Deck OLED (SteamOS 3.8), against the live root `sunshine.conf`:
- Reads the current encoder correctly.
- Selecting VAAPI / Vulkan writes the value and **preserves `hevc_mode`**; selecting Auto removes the `encoder` key (other keys untouched); an invalid value is rejected without modifying the file.
- With Sunshine running, changing the encoder restarts it and the new encoder is the one Sunshine loads (confirmed via the `Creating encoder [...]` line in the journal).
- Plugin reloads clean (no traceback); frontend builds and renders the dropdown.

---

**Note on overlap with #95:** this PR and #95 (force composition toggle) each add the same two helper files, `src/components/InfoModal.tsx` and `src/components/LabelWithInfo.tsx`. They are byte-identical in both branches. If both PRs are merged, expect a trivial "file added on both branches" conflict — just keep either copy. The `src/index.tsx` edits touch different sections (this one the encoder dropdown; #95 the force-composition toggle) and don't otherwise overlap.