### PR TITLE
Improve audio socket selection (builds on #94)

### DIFF
--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -64,6 +64,10 @@ class SunshineController:
 
     authHeader = ""
 
+    # Whether the socket-discovery fallback warning has already been logged;
+    # kept as state so the retry loop in start_async does not repeat it every second
+    _socket_fallback_warned = False
+
     def __init__(self, logger) -> None:
         """
         Initialize the SunshineController instance.
@@ -506,6 +510,7 @@ class SunshineController:
 
         seen_socket_patterns = set()
         seen_socket_paths = set()
+        existing_not_connectable = []
         for pattern in socket_patterns:
             if pattern in seen_socket_patterns:
                 continue
@@ -519,14 +524,28 @@ class SunshineController:
                 if socket_path in seen_socket_paths:
                     continue
                 seen_socket_paths.add(socket_path)
-                if os.path.exists(socket_path) and self._canConnectToAudioSocket(socket_path):
+                if not os.path.exists(socket_path):
+                    continue
+                if self._canConnectToAudioSocket(socket_path):
+                    # Re-arm the fallback warning so a later regression is reported again
+                    self._socket_fallback_warned = False
                     return socket_path
+                existing_not_connectable.append(socket_path)
 
-        # If no existing socket path was found, return a default path
+        # If no usable socket was found, return a default path
         # Try to use deck user's UID if found, otherwise use 1000
         default_uid = deck_uid if deck_uid else 1000
         default_socket = f"/run/user/{default_uid}/pulse/native"
-        self.logger.warning(f"No PulseAudio socket found, using default: {default_socket}")
+        if existing_not_connectable:
+            message = (f"PulseAudio socket(s) found but not accepting connections (yet): "
+                       f"{', '.join(existing_not_connectable)} - using default: {default_socket}")
+        else:
+            message = f"No PulseAudio socket found, using default: {default_socket}"
+        if self._socket_fallback_warned:
+            self.logger.debug(message)
+        else:
+            self.logger.warning(message)
+            self._socket_fallback_warned = True
         return default_socket
 
     @staticmethod

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -82,7 +82,14 @@ class SunshineController:
         self.opener = build_opener(NoRedirect(), HTTPSHandler(context=sslContext))
 
         self.environment_variables = os.environ.copy()
-        self.environment_variables["PULSE_SERVER"] = f"unix:{self._findPulseAudioSocketPath()}"
+        # A PULSE_SERVER present in the inherited environment can only have been
+        # configured deliberately (e.g. via a systemd drop-in for the Decky
+        # loader service), so respect it and skip socket discovery entirely.
+        external_pulse_server = os.environ.get("PULSE_SERVER")
+        if external_pulse_server:
+            self.logger.info(f"Using externally configured PULSE_SERVER: {external_pulse_server}")
+        else:
+            self.environment_variables["PULSE_SERVER"] = f"unix:{self._findPulseAudioSocketPath()}"
         self.environment_variables["DISPLAY"] = ":0"
         self.environment_variables["FLATPAK_BWRAP"] = self.environment_variables.get("DECKY_PLUGIN_RUNTIME_DIR", "") + "/bwrap"
         self.environment_variables["LD_LIBRARY_PATH"] = "/usr/lib/:" + self.environment_variables.get("LD_LIBRARY_PATH", "")
@@ -620,6 +627,17 @@ class SunshineController:
         how Sunshine checks for audio availability.
         :return: True if audio is available, otherwise False.
         """
+        # An externally configured PULSE_SERVER overrides socket discovery entirely
+        external_pulse_server = os.environ.get("PULSE_SERVER")
+        if external_pulse_server:
+            if external_pulse_server.startswith("unix:"):
+                socket_path = external_pulse_server[len("unix:"):]
+                if not (os.path.exists(socket_path) and self._canConnectToAudioSocket(socket_path)):
+                    self.logger.debug(f"Externally configured PULSE_SERVER is not connectable (yet): {external_pulse_server}")
+                    return False
+            # Non-unix values (e.g. tcp:host:port) are trusted without a check
+            return True
+
         # Re-evaluate the best socket each time, as the correct socket may not have existed on startup (cold boot)
         pulse_socket_path = self._findPulseAudioSocketPath()
 

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -9,6 +9,7 @@ import secrets
 import glob
 import socket
 import pwd
+import re
 
 from typing import Sequence
 from urllib.error import URLError
@@ -510,7 +511,7 @@ class SunshineController:
                 continue
             seen_socket_patterns.add(pattern)
 
-            matches = glob.glob(pattern) if '*' in pattern else [pattern]
+            matches = self._expandSocketPattern(pattern) if '*' in pattern else [pattern]
             for socket_path in matches:
                 # Skip root user's socket (uid 0)
                 if '/run/user/0/' in socket_path:
@@ -527,6 +528,29 @@ class SunshineController:
         default_socket = f"/run/user/{default_uid}/pulse/native"
         self.logger.warning(f"No PulseAudio socket found, using default: {default_socket}")
         return default_socket
+
+    @staticmethod
+    def _expandSocketPattern(pattern: str) -> list:
+        """
+        Expand a glob pattern into a deterministic list of candidate socket paths.
+        glob returns matches in filesystem readdir order, which is effectively
+        random; sorting numerically by UID makes the search order reproducible
+        across boots and systems.
+        Sockets of system users (uid < 1000) are skipped: display-manager
+        greeters like gdm/sddm run their own PipeWire/PulseAudio instance whose
+        socket must not win over the session user's one.
+        :param pattern: The glob pattern to expand
+        :return: Matching paths, sorted numerically by UID (non-/run/user
+                 matches such as /tmp/pulse-* sort last, lexically)
+        """
+        matches = []
+        for socket_path in glob.glob(pattern):
+            uid_match = re.match(r"^/run/user/(\d+)/", socket_path)
+            uid = int(uid_match.group(1)) if uid_match else None
+            if uid is not None and uid < 1000:
+                continue
+            matches.append((uid is None, uid or 0, socket_path))
+        return [socket_path for _, _, socket_path in sorted(matches)]
 
     def _canConnectToAudioSocket(self, socket_path: str) -> bool:
         try:

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -462,14 +462,19 @@ class SunshineController:
             request.data = json.dumps(data).encode('utf-8')
         return request
 
-    def _getPulseAudioSocketPathCandidates(self) -> tuple[list[str], int | None]:
+    def _findPulseAudioSocketPath(self) -> str:
         """
-        Get PulseAudio/PipeWire socket path candidates in preference order.
-        :return: A tuple with candidate paths and the deck user's UID if available
+        Find the PulseAudio/PipeWire socket path.
+        Searches common locations and returns the first connectable socket found.
+        :return: The socket path in the format "/path/to/socket", or a default path if not found
         """
+        # Try to get XDG_RUNTIME_DIR first, which is the standard location
         xdg_runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+
+        # Build socket patterns to check (in order of preference)
         socket_patterns = []
 
+        # If XDG_RUNTIME_DIR is set and it's not root's directory, prioritize it
         if xdg_runtime_dir and '/run/user/0' not in xdg_runtime_dir:
             socket_patterns.extend([
                 f"{xdg_runtime_dir}/pulse/native",
@@ -500,30 +505,23 @@ class SunshineController:
             "/tmp/pulse-*/native",
         ])
 
-        socket_paths = []
-        seen_paths = set()
+        seen_socket_patterns = set()
+        seen_socket_paths = set()
         for pattern in socket_patterns:
+            if pattern in seen_socket_patterns:
+                continue
+            seen_socket_patterns.add(pattern)
+
             matches = glob.glob(pattern) if '*' in pattern else [pattern]
             for socket_path in matches:
+                # Skip root user's socket (uid 0)
                 if '/run/user/0/' in socket_path:
                     continue
-                if socket_path not in seen_paths:
-                    socket_paths.append(socket_path)
-                    seen_paths.add(socket_path)
-
-        return socket_paths, deck_uid
-
-    def _findPulseAudioSocketPath(self) -> str:
-        """
-        Find the PulseAudio/PipeWire socket path.
-        Searches common locations and returns the first existing socket found.
-        :return: The socket path in the format "/path/to/socket", or a default path if not found
-        """
-        socket_paths, deck_uid = self._getPulseAudioSocketPathCandidates()
-
-        for socket_path in socket_paths:
-            if os.path.exists(socket_path):
-                return socket_path
+                if socket_path in seen_socket_paths:
+                    continue
+                seen_socket_paths.add(socket_path)
+                if os.path.exists(socket_path) and self._canConnectToAudioSocket(socket_path):
+                    return socket_path
 
         # If no existing socket path was found, return a default path
         # Try to use deck user's UID if found, otherwise use 1000
@@ -544,22 +542,6 @@ class SunshineController:
         except Exception as e:
             self.logger.exception("Unexpected error checking audio availability", exc_info=e)
             return False
-
-    def _findWorkingPulseAudioSocketPath(self) -> str | None:
-        """
-        Find the first existing audio socket that can actually be connected to.
-        """
-        socket_paths, _ = self._getPulseAudioSocketPathCandidates()
-
-        for socket_path in socket_paths:
-            if not os.path.exists(socket_path):
-                self.logger.debug(f"Audio socket does not exist: {socket_path}")
-                continue
-
-            if self._canConnectToAudioSocket(socket_path):
-                return socket_path
-
-        return None
 
     def _isDisplayAvailable(self) -> bool:
         """
@@ -597,9 +579,16 @@ class SunshineController:
         how Sunshine checks for audio availability.
         :return: True if audio is available, otherwise False.
         """
-        # Re-evaluate the best socket each time, as the correct socket may not have existed on startup.
-        pulse_socket_path = self._findWorkingPulseAudioSocketPath()
-        if not pulse_socket_path:
+        # Re-evaluate the best socket each time, as the correct socket may not have existed on startup (cold boot)
+        pulse_socket_path = self._findPulseAudioSocketPath()
+
+        # Checking whether the socket path exists should only fail in case we had to use a default path
+        if not os.path.exists(pulse_socket_path):
+            self.logger.debug(f"Audio socket does not exist: {pulse_socket_path}")
+            return False
+
+        # Try to connect to the socket to verify it's actually working
+        if not self._canConnectToAudioSocket(pulse_socket_path):
             return False
 
         # Update the environment variable if a different working socket was found so Sunshine will use it

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -462,20 +462,14 @@ class SunshineController:
             request.data = json.dumps(data).encode('utf-8')
         return request
 
-    def _findPulseAudioSocketPath(self) -> str:
+    def _getPulseAudioSocketPathCandidates(self) -> tuple[list[str], int | None]:
         """
-        Find the PulseAudio/PipeWire socket path.
-        Searches common locations and returns the first valid socket found.
-        :return: The socket path in the format "/path/to/socket", or a default path if not found
+        Get PulseAudio/PipeWire socket path candidates in preference order.
+        :return: A tuple with candidate paths and the deck user's UID if available
         """
-
-        # Try to get XDG_RUNTIME_DIR first, which is the standard location
         xdg_runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
-
-        # Build socket patterns to check (in order of preference)
         socket_patterns = []
 
-        # If XDG_RUNTIME_DIR is set and it's not root's directory, prioritize it
         if xdg_runtime_dir and '/run/user/0' not in xdg_runtime_dir:
             socket_patterns.extend([
                 f"{xdg_runtime_dir}/pulse/native",
@@ -506,14 +500,30 @@ class SunshineController:
             "/tmp/pulse-*/native",
         ])
 
+        socket_paths = []
+        seen_paths = set()
         for pattern in socket_patterns:
             matches = glob.glob(pattern) if '*' in pattern else [pattern]
             for socket_path in matches:
-                # Skip root user's socket (uid 0)
                 if '/run/user/0/' in socket_path:
                     continue
-                if os.path.exists(socket_path):
-                    return socket_path
+                if socket_path not in seen_paths:
+                    socket_paths.append(socket_path)
+                    seen_paths.add(socket_path)
+
+        return socket_paths, deck_uid
+
+    def _findPulseAudioSocketPath(self) -> str:
+        """
+        Find the PulseAudio/PipeWire socket path.
+        Searches common locations and returns the first existing socket found.
+        :return: The socket path in the format "/path/to/socket", or a default path if not found
+        """
+        socket_paths, deck_uid = self._getPulseAudioSocketPathCandidates()
+
+        for socket_path in socket_paths:
+            if os.path.exists(socket_path):
+                return socket_path
 
         # If no existing socket path was found, return a default path
         # Try to use deck user's UID if found, otherwise use 1000
@@ -521,6 +531,35 @@ class SunshineController:
         default_socket = f"/run/user/{default_uid}/pulse/native"
         self.logger.warning(f"No PulseAudio socket found, using default: {default_socket}")
         return default_socket
+
+    def _canConnectToAudioSocket(self, socket_path: str) -> bool:
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(1)
+                sock.connect(socket_path)
+            return True
+        except (socket.error, OSError) as e:
+            self.logger.debug(f"Cannot connect to audio socket {socket_path}: {e}")
+            return False
+        except Exception as e:
+            self.logger.exception("Unexpected error checking audio availability", exc_info=e)
+            return False
+
+    def _findWorkingPulseAudioSocketPath(self) -> str | None:
+        """
+        Find the first existing audio socket that can actually be connected to.
+        """
+        socket_paths, _ = self._getPulseAudioSocketPathCandidates()
+
+        for socket_path in socket_paths:
+            if not os.path.exists(socket_path):
+                self.logger.debug(f"Audio socket does not exist: {socket_path}")
+                continue
+
+            if self._canConnectToAudioSocket(socket_path):
+                return socket_path
+
+        return None
 
     def _isDisplayAvailable(self) -> bool:
         """
@@ -558,25 +597,9 @@ class SunshineController:
         how Sunshine checks for audio availability.
         :return: True if audio is available, otherwise False.
         """
-        # Re-evaluate the best socket each time, as the correct socket may not have existed on startup (cold boot)
-        pulse_socket_path = self._findPulseAudioSocketPath()
-
-        # Checking whether the socket path exists should only fail in case we had to use a default path
-        if not os.path.exists(pulse_socket_path):
-            self.logger.debug(f"Audio socket does not exist: {pulse_socket_path}")
-            return False
-
-        # Try to connect to the socket to verify it's actually working
-        try:
-            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            sock.settimeout(1)
-            sock.connect(pulse_socket_path)
-            sock.close()
-        except (socket.error, OSError) as e:
-            self.logger.debug(f"Cannot connect to audio socket {pulse_socket_path}: {e}")
-            return False
-        except Exception as e:
-            self.logger.exception(f"Unexpected error checking audio availability", exc_info=e)
+        # Re-evaluate the best socket each time, as the correct socket may not have existed on startup.
+        pulse_socket_path = self._findWorkingPulseAudioSocketPath()
+        if not pulse_socket_path:
             return False
 
         # Update the environment variable if a different working socket was found so Sunshine will use it

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -515,29 +515,29 @@ class SunshineController:
             "/tmp/pulse-*/native",
         ])
 
-        seen_socket_patterns = set()
-        seen_socket_paths = set()
-        existing_not_connectable = []
+        # Build a duplicate-free candidate list before probing: the same path can
+        # arrive via several patterns (e.g. XDG_RUNTIME_DIR, the deck user entry
+        # and the /run/user/* glob), and each socket should only get one connect
+        # attempt and appear only once in the fallback log below.
+        candidate_paths = []
         for pattern in socket_patterns:
-            if pattern in seen_socket_patterns:
-                continue
-            seen_socket_patterns.add(pattern)
-
             matches = self._expandSocketPattern(pattern) if '*' in pattern else [pattern]
             for socket_path in matches:
-                # Skip root user's socket (uid 0)
-                if '/run/user/0/' in socket_path:
-                    continue
-                if socket_path in seen_socket_paths:
-                    continue
-                seen_socket_paths.add(socket_path)
-                if not os.path.exists(socket_path):
-                    continue
-                if self._canConnectToAudioSocket(socket_path):
-                    # Re-arm the fallback warning so a later regression is reported again
-                    self._socket_fallback_warned = False
-                    return socket_path
-                existing_not_connectable.append(socket_path)
+                if socket_path not in candidate_paths:
+                    candidate_paths.append(socket_path)
+
+        existing_not_connectable = []
+        for socket_path in candidate_paths:
+            # Skip root user's socket (uid 0)
+            if '/run/user/0/' in socket_path:
+                continue
+            if not os.path.exists(socket_path):
+                continue
+            if self._canConnectToAudioSocket(socket_path):
+                # Re-arm the fallback warning so a later regression is reported again
+                self._socket_fallback_warned = False
+                return socket_path
+            existing_not_connectable.append(socket_path)
 
         # If no usable socket was found, return a default path
         # Try to use deck user's UID if found, otherwise use 1000

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -464,8 +464,13 @@ class SunshineController:
 
     def _findPulseAudioSocketPath(self) -> str:
         """
-        Find the PulseAudio/PipeWire socket path.
-        Searches common locations and returns the first connectable socket found.
+        Find the PulseAudio protocol socket path (on PipeWire systems provided
+        by pipewire-pulse). Searches common locations and returns the first
+        connectable socket found.
+        Note that pipewire-0 sockets are deliberately not considered: PULSE_SERVER
+        must point to a socket speaking the PulseAudio protocol, while pipewire-0
+        speaks the PipeWire native protocol -- it would accept a connection but be
+        unusable for Sunshine's libpulse client.
         :return: The socket path in the format "/path/to/socket", or a default path if not found
         """
         # Try to get XDG_RUNTIME_DIR first, which is the standard location
@@ -476,10 +481,7 @@ class SunshineController:
 
         # If XDG_RUNTIME_DIR is set and it's not root's directory, prioritize it
         if xdg_runtime_dir and '/run/user/0' not in xdg_runtime_dir:
-            socket_patterns.extend([
-                f"{xdg_runtime_dir}/pulse/native",
-                f"{xdg_runtime_dir}/pipewire-0",
-            ])
+            socket_patterns.append(f"{xdg_runtime_dir}/pulse/native")
 
         # Next, add the socket directories for the user 'deck'.
         # Note that we determine the UID of the specific user 'deck' here to prioritize it,
@@ -489,19 +491,15 @@ class SunshineController:
         try:
             deck_user = pwd.getpwnam('deck')
             deck_uid = deck_user.pw_uid
-            socket_patterns.extend([
-                f"/run/user/{deck_uid}/pulse/native",
-                f"/run/user/{deck_uid}/pipewire-0",
-            ])
+            socket_patterns.append(f"/run/user/{deck_uid}/pulse/native")
         except KeyError:
             # User 'deck' does not exist, which is expected on non-Steam Deck systems
             pass
 
-        # Finally, add all /run/user/*/pulse/native and /run/user/*/pipewire-0 socket directories.
+        # Finally, add all /run/user/*/pulse/native socket directories.
         # This will find sockets for any user (1000, 1001, etc.)
         socket_patterns.extend([
             "/run/user/*/pulse/native",
-            "/run/user/*/pipewire-0",
             "/tmp/pulse-*/native",
         ])
 


### PR DESCRIPTION
## Summary
Builds on @shenmintao's connectability fix from #94 (both commits included as-is) and hardens the socket discovery around it:

- **Remove pipewire-0 sockets from PULSE_SERVER candidates** — `pipewire-0` speaks the PipeWire native protocol; it accepts a plain unix connect but is unusable for Sunshine's libpulse client. Harmless dead weight before #94, but with the connectability check an existing-but-not-yet-ready `pulse/native` could be skipped in favor of `pipewire-0`, leaving Sunshine without audio.
- **Make glob socket search deterministic and skip system users' sockets** — glob returns readdir order; sort numerically by UID and skip uid < 1000 so display-manager greeters (gdm/sddm run their own PipeWire instance) can't win over the session user's socket.
- **Differentiate socket fallback logging and warn only once** — "found but not accepting connections (yet)" vs. "not found", warned once per failure phase instead of every second of the retry loop.
- **Respect externally configured PULSE_SERVER** — a value present in the service environment (e.g. via a systemd drop-in) is configured deliberately; keep it and skip discovery. `unix:` values still participate in the startup wait loop via a connectability check.
- **Simplify candidate de-duplication** (refactor, no behavior change).

## Testing
- Scenario harness (mocked sockets/users/env): first-connectable selection, cold boot, pipewire-0 exclusion, greeter-vs-user, PULSE_SERVER override (unix connectable/unreachable/tcp)
- Live on Steam Deck (SteamOS, cold boot + simulated audio outage via stopped pipewire units): single differentiated warning, no log spam, correct socket picked once audio came up, streaming with working audio

Supersedes #94 — thanks @shenmintao for the original fix and the CachyOS analysis!

🤖 Generated with [Claude Code](https://claude.com/claude-code)