### PR TITLE
Fix correctness, security and maintainability issues from code review

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ class Plugin:
         return self.settingManager.getSetting(key, default)
 
     async def isSunshineRunning(self):
-        current_is_running = self.sunshineController.isSunshineRunning()
+        current_is_running = await self.sunshineController.isSunshineRunning_async()
         if self._last_is_running != current_is_running:
             decky.logger.info(f"Sunshine running state changed: {self._last_is_running if self._last_is_running is not None else 'unknown'} → {current_is_running if current_is_running is not None else 'unknown'}")
             self._last_is_running = current_is_running
@@ -85,8 +85,8 @@ class Plugin:
         decky.logger.info(f"Credentials found")
         return credentials
 
-    async def getSunshineVersionInfo(self):
-        versionInfo = self.sunshineController.getSunshineVersionInfo()
+    async def getSunshineVersionInfo(self, refresh_appstream = True):
+        versionInfo = await self.sunshineController.getSunshineVersionInfo_async(refresh_appstream)
         if versionInfo:
             last_current_version = self._last_version_info["current_version"] or 'unknown' if self._last_version_info else 'unknown'
             last_update_version = self._last_version_info["update_version"] or 'unknown' if self._last_version_info else 'unknown'

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -33,24 +33,13 @@ class RequestResult:
     data: dict | None
     error: RequestError | None
 
-    def __init__(self, *args, **kwargs):
-        raise RuntimeError("Use factory methods: RequestResult.success() or RequestResult.error()")
+    @classmethod
+    def success(cls, data: dict) -> "RequestResult":
+        return cls(ok=True, data=data, error=None)
 
     @classmethod
-    def success(cls, data: dict):
-        self = object.__new__(cls)
-        object.__setattr__(self, "ok", True)
-        object.__setattr__(self, "data", data)
-        object.__setattr__(self, "error", None)
-        return self
-
-    @classmethod
-    def error(cls, error: RequestError):
-        self = object.__new__(cls)
-        object.__setattr__(self, "ok", False)
-        object.__setattr__(self, "data", None)
-        object.__setattr__(self, "error", error)
-        return self
+    def failure(cls, error: RequestError) -> "RequestResult":
+        return cls(ok=False, data=None, error=error)
 
     def is_unauthorized(self) -> bool:
         return self.error == RequestError.UNAUTHORIZED
@@ -91,7 +80,16 @@ class SunshineController:
         else:
             self.environment_variables["PULSE_SERVER"] = f"unix:{self._findPulseAudioSocketPath()}"
         self.environment_variables["DISPLAY"] = ":0"
-        self.environment_variables["FLATPAK_BWRAP"] = self.environment_variables.get("DECKY_PLUGIN_RUNTIME_DIR", "") + "/bwrap"
+        # bwrap must be setuid root (Sunshine needs CAP_SYS_ADMIN for KMS/DRM
+        # capture, which the setuid copy grants inside the flatpak sandbox) and
+        # it is executed by the root plugin. It must therefore live in a
+        # directory that (a) sits on a suid-capable filesystem and (b) is
+        # writable by root only - otherwise any process running as the deck user
+        # could swap the binary and have it executed as root.
+        # DECKY_PLUGIN_RUNTIME_DIR is owned by (and writable to) deck, and
+        # /run + /tmp are mounted nosuid, so none of those work. /var/lib is
+        # root-owned on a suid-capable ext4 mount, so we use a directory there.
+        self.environment_variables["FLATPAK_BWRAP"] = "/var/lib/decky-sunshine/bwrap"
         self.environment_variables["LD_LIBRARY_PATH"] = "/usr/lib/:" + self.environment_variables.get("LD_LIBRARY_PATH", "")
 
     def setCredentials(self, username, password) -> str:
@@ -140,12 +138,19 @@ class SunshineController:
         )
         return any(line.strip() == self.SunshineFlatpakAppId for line in (result or "").splitlines())
 
+    async def isSunshineRunning_async(self) -> bool:
+        """
+        Async variant of isSunshineRunning that doesn't block the event loop.
+        :return: True if Sunshine is running, False otherwise
+        """
+        return await self._to_thread(self.isSunshineRunning)
+
     async def areCredentialsValid_async(self) -> bool | None:
         """
         Check whether the current credentials are valid by making a request to the Sunshine server.
         :return: True if credentials are valid, False if invalid, None if Sunshine is not running or another error occurred
         """
-        if not self.isSunshineRunning():
+        if not await self.isSunshineRunning_async():
             return None
         res = await self._request_async("/api/apps")
         if res.ok:
@@ -163,18 +168,18 @@ class SunshineController:
             self.logger.info("Decky Sunshine's copy of bwrap was already obtained.")
         else:
             self.logger.info("Decky Sunshine's copy of bwrap is missing. Obtaining now...")
-            installed = self._copyBwrap()
+            installed = await self._to_thread(self._copyBwrap)
             if not installed:
                 self.logger.error("Decky Sunshine's copy of bwrap could not be obtained.")
                 return False
             self.logger.info("Decky Sunshine's copy of bwrap obtained successfully.")
 
-        if self._isSunshineInstalled():
+        if await self._to_thread(self._isSunshineInstalled):
             self.logger.info("Sunshine already installed.")
             return True
         else:
             self.logger.info("Sunshine not installed. Installing...")
-            installed = self._installOrUpdateSunshine()
+            installed = await self._to_thread(self._installOrUpdateSunshine)
             if not installed:
                 self.logger.error("Sunshine could not be installed.")
                 return False
@@ -186,7 +191,7 @@ class SunshineController:
         Start the Sunshine process.
         :return: True if Sunshine was started successfully or is already running, False otherwise
         """
-        if self.isSunshineRunning():
+        if await self.isSunshineRunning_async():
             return True
 
         retry_count = 60
@@ -196,8 +201,8 @@ class SunshineController:
         # or the audio subsystem may not be ready. Thus, we check whether both are available before
         # starting Sunshine.
         while retry_count > 0:
-            display_available = self._isDisplayAvailable()
-            audio_available = self._isAudioAvailable()
+            display_available = await self._to_thread(self._isDisplayAvailable)
+            audio_available = await self._to_thread(self._isAudioAvailable)
 
             if display_available and audio_available:
                 break
@@ -223,21 +228,26 @@ class SunshineController:
         elif display_available:
             self.logger.info("Display available")
 
-        # Set the permissions for our bwrap
         bwrap_path = self.environment_variables["FLATPAK_BWRAP"]
 
-        if not self._run_and_check(['chown', '0:0', bwrap_path], context="setting owner on bwrap to root"):
+        # Re-copy bwrap from the trusted system binary on every start (this also
+        # picks up bwrap updates from the OS) and make it setuid root, which
+        # Sunshine needs for KMS/DRM capture. This is safe because the target
+        # directory is writable by root only (see __init__).
+        if not await self._to_thread(self._copyBwrap):
             return False
 
-        if not self._run_and_check(['chmod', 'u+s', bwrap_path], context="setting setuid on bwrap"):
+        if not await self._to_thread(lambda: self._run_and_check(['chown', '0:0', bwrap_path], context="setting owner on bwrap to root")):
+            return False
+
+        if not await self._to_thread(lambda: self._run_and_check(['chmod', 'u+s', bwrap_path], context="setting setuid on bwrap")):
             return False
 
         # Run Sunshine
         try:
-            subprocess.Popen(f"sh -c 'flatpak run --system --socket=wayland {self.SunshineFlatpakAppId}'",
+            subprocess.Popen(["flatpak", "run", "--system", "--socket=wayland", self.SunshineFlatpakAppId],
                              env=self.environment_variables,
-                             shell=True,
-                             preexec_fn=os.setsid)
+                             start_new_session=True)
         except Exception as e:
             self.logger.exception("An error occurred when starting Sunshine", exc_info=e)
             return False
@@ -245,7 +255,7 @@ class SunshineController:
         # Wait for Sunshine to start
         retry_count = 20
         wait_time = 0.25
-        while not self.isSunshineRunning() and retry_count > 0:
+        while not await self.isSunshineRunning_async() and retry_count > 0:
             retry_count -= 1
             if retry_count == 0:
                 self.logger.error("Aborting wait for Sunshine process to start.")
@@ -260,14 +270,14 @@ class SunshineController:
         Stop the Sunshine process.
         :return: True if Sunshine was stopped successfully or wasn't running, False otherwise
         """
-        if not self.isSunshineRunning():
+        if not await self.isSunshineRunning_async():
             return True
 
-        self._run_and_check(["flatpak", "kill", self.SunshineFlatpakAppId], context="killing Sunshine via flatpak")
+        await self._to_thread(lambda: self._run_and_check(["flatpak", "kill", self.SunshineFlatpakAppId], context="killing Sunshine via flatpak"))
 
         retry_count = 20
         wait_time = 0.25
-        while self.isSunshineRunning() and retry_count > 0:
+        while await self.isSunshineRunning_async() and retry_count > 0:
             retry_count -= 1
             if retry_count == 0:
                 self.logger.error("Aborting wait for Sunshine process to end.")
@@ -316,9 +326,17 @@ class SunshineController:
 
         return count_after == count_before + 1
 
-    def getSunshineVersionInfo(self) -> dict | None:
+    async def getSunshineVersionInfo_async(self, refresh_appstream: bool = True) -> dict | None:
+        """
+        Async variant of getSunshineVersionInfo that doesn't block the event loop.
+        """
+        return await self._to_thread(lambda: self.getSunshineVersionInfo(refresh_appstream))
+
+    def getSunshineVersionInfo(self, refresh_appstream: bool = True) -> dict | None:
         """
         Get the current and available update version of Sunshine.
+        :param refresh_appstream: Whether to refresh the Flatpak appstream data (requires network access
+                                  and can take a while) before checking for an update
         :return: A dict with keys 'current_version' and 'update_version', or None if an error occurred
         """
         info_result = self._run_and_capture_stdout(
@@ -331,7 +349,8 @@ class SunshineController:
             for (_, version) in (line.split(":", 1) for line in info_result.splitlines() if "Version:" in line):
                 current_version = version.strip()
 
-        self._run_and_check(['flatpak', 'update', '--appstream'], context="refreshing Flatpak appstream data")
+        if refresh_appstream:
+            self._run_and_check(['flatpak', 'update', '--appstream'], context="refreshing Flatpak appstream data")
 
         result = self._run_and_capture_stdout(
             ["flatpak", "remote-ls", "--app", "--updates", "--system", "--columns=application,version"],
@@ -340,8 +359,9 @@ class SunshineController:
 
         update_version = None
         if result:
-            for (_, version) in (line.split() for line in result.splitlines() if self.SunshineFlatpakAppId in line):
-                update_version = version.strip()
+            # The version column can be empty, in which case the line only contains the application id
+            for columns in (line.split() for line in result.splitlines() if self.SunshineFlatpakAppId in line):
+                update_version = columns[1] if len(columns) > 1 else None
 
         return {
             "current_version": current_version,
@@ -358,7 +378,7 @@ class SunshineController:
             self.logger.error("Couldn't stop Sunshine for update")
             return False
         self.logger.info("Sunshine stopped for update. Installing update now...")
-        installed = self._installOrUpdateSunshine()
+        installed = await self._to_thread(self._installOrUpdateSunshine)
         if not installed:
             self.logger.error("Couldn't update Sunshine")
             return False
@@ -404,6 +424,15 @@ class SunshineController:
         proc = self._run(args, context)
         return proc.stdout if proc else None
 
+    async def _to_thread(self, func):
+        """
+        Run a blocking callable in the default executor so it doesn't block the event loop.
+        :param func: The callable to run (without arguments; use a lambda to bind arguments)
+        :return: The return value of the callable
+        """
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, func)
+
     async def _request_async(self, path, data=None) -> RequestResult:
         """
         Make an async HTTP request to the Sunshine server.
@@ -423,20 +452,22 @@ class SunshineController:
         """
         try:
             request = self._createRequest(path, data)
-            with self.opener.open(request) as response:
+            # The timeout must be passed here: OpenerDirector.open() unconditionally
+            # overwrites a timeout attribute set on the Request object.
+            with self.opener.open(request, timeout=5) as response:
                 if response.getcode() != OK:
                     self.logger.error(f"Request to path '{path}' with data '{data}' failed with code: {response.getcode()}")
-                    return RequestResult.error(RequestError.OTHER)
+                    return RequestResult.failure(RequestError.OTHER)
                 encoding = response.headers.get_content_charset() or "utf-8"
                 content = response.read().decode(encoding)
                 return RequestResult.success(json.loads(content))
 
         except HTTPError as e:
             if e.code == UNAUTHORIZED:
-                return RequestResult.error(RequestError.UNAUTHORIZED)
+                return RequestResult.failure(RequestError.UNAUTHORIZED)
             else:
                 self.logger.error(f"HTTP error in request to path '{path}' with data '{data}', code: {e.code}, reason: {e.reason}")
-                return RequestResult.error(RequestError.OTHER)
+                return RequestResult.failure(RequestError.OTHER)
 
         except URLError as e:
             # Check if the reason is a connection refusal,
@@ -445,14 +476,14 @@ class SunshineController:
                 isinstance(e.reason, OSError) and getattr(e.reason, "errno", None) == 111
             ):
                 self.logger.error(f"Server not reachable when requesting path '{path}' with data '{data}': Connection refused")
-                return RequestResult.error(RequestError.UNREACHABLE)
+                return RequestResult.failure(RequestError.UNREACHABLE)
             else:
                 self.logger.error(f"URL error in request to path '{path}' with data '{data}', reason: {e.reason}")
-                return RequestResult.error(RequestError.OTHER)
+                return RequestResult.failure(RequestError.OTHER)
 
         except Exception as e:
             self.logger.exception(f"An error occurred when performing a request to path '{path}' with data '{data}'", exc_info=e)
-            return RequestResult.error(RequestError.OTHER)
+            return RequestResult.failure(RequestError.OTHER)
 
     def _createRequest(self, path, data=None) -> Request:
         """
@@ -464,7 +495,6 @@ class SunshineController:
         sunshineBaseUrl = "https://127.0.0.1:47990"
         url = sunshineBaseUrl + path
         request = Request(url)
-        request.timeout = 5
         request.add_header("User-Agent", "decky-sunshine")
         request.add_header("Connection", "keep-alive")
         request.add_header("Accept", "application/json, */*; q=0.01")
@@ -602,10 +632,11 @@ class SunshineController:
             data = json.loads(result or "{}")
         except Exception as e:
             self.logger.exception("An error occurred when parsing the output of drm_info", exc_info=e)
+            data = None
 
         data = data or {}
         for _, card in data.items():
-            for connector in card.get("crtcs", []):
+            for crtc in card.get("crtcs", []):
                 # Sunshine checks for the crtcs of a plane with a fb_id that is not 0.
                 # https://github.com/LizardByte/Sunshine/blob/6ab24491ed0463eb60c8b902e018d98be3afd06b/src/platform/linux/kmsgrab.cpp#L1620
                 # If the fb_id is 0, the crtc will be skipped.
@@ -616,7 +647,7 @@ class SunshineController:
                 # and there was no fb_id != 0 directly after start, but only later. Thus,
                 # it should be sufficient to find a single fb_id != 0 to determine that
                 # Sunshine should be able to find a display as well.
-                if connector.get("fb_id", 0) != 0:
+                if crtc.get("fb_id", 0) != 0:
                     return True
         return False
 
@@ -689,12 +720,22 @@ class SunshineController:
 
     def _copyBwrap(self) -> bool:
         """
-        Copy the bwrap binary to the expected location.
+        Copy the bwrap binary to its dedicated root-owned directory.
         :return: True if the copy was successful, False otherwise
         """
+        bwrap_path = self.environment_variables["FLATPAK_BWRAP"]
+        bwrap_dir = os.path.dirname(bwrap_path)
+        try:
+            os.makedirs(bwrap_dir, exist_ok=True)
+            # makedirs is subject to the umask, so set the mode explicitly: the
+            # directory must not be writable by anyone but root.
+            os.chmod(bwrap_dir, 0o755)
+        except Exception as e:
+            self.logger.exception("An error occurred when creating the bwrap directory", exc_info=e)
+            return False
         return self._run_and_check(
-                ["cp", "/usr/bin/bwrap", self.environment_variables["FLATPAK_BWRAP"]],
-                context="copying bwrap to Decky Plugin Runtime directory"
+                ["cp", "/usr/bin/bwrap", bwrap_path],
+                context="copying bwrap to its dedicated directory"
         )
 
     def _installOrUpdateSunshine(self) -> bool:

--- a/src/components/CredentialsModal.tsx
+++ b/src/components/CredentialsModal.tsx
@@ -9,11 +9,11 @@ export const CredentialsModal: VFC<{
     onLogin: (username: string, password: string) => Promise<boolean | null>;
 }> = ({
         closeModal,
-        onLogin: onLogin,
+        onLogin,
       }) => {
     const [localUsername, setLocalUsername] = useState(localStorage.getItem("decky_sunshine:localUsername") || "decky_sunshine");
     const [localPassword, setLocalPassword] = useState("");
-    const [wasLoginSucessful, setWasLoginSucessful ] = useState<boolean | null>(null);
+    const [wasLoginSuccessful, setWasLoginSuccessful ] = useState<boolean | null>(null);
     const [hadErrorOnLogin, setHadErrorOnLogin ] = useState<boolean>(false);
     const [isWaitingForResponse, setIsWaitingForResponse ] = useState(false);
 
@@ -28,7 +28,7 @@ export const CredentialsModal: VFC<{
       }
 
       setIsWaitingForResponse(false);
-      setWasLoginSucessful(success);
+      setWasLoginSuccessful(success);
       setHadErrorOnLogin(success === null);
     }
 
@@ -39,19 +39,19 @@ export const CredentialsModal: VFC<{
             value={localUsername}
             style={{ width: '20em' }}
             bShowClearAction={localUsername.length > 0}
-            onChange={(e) => {setLocalUsername(e.target.value); setWasLoginSucessful(null);}}
+            onChange={(e) => {setLocalUsername(e.target.value); setWasLoginSuccessful(null);}}
           />
         </Field>
         <Field label="Password">
           <PasswordInput
             value={localPassword}
             style={{ width: '20em' }}
-            onChange={(value) => {setLocalPassword(value); setWasLoginSucessful(null);}}
+            onChange={(value) => {setLocalPassword(value); setWasLoginSuccessful(null);}}
           />
         </Field>
         {hadErrorOnLogin && <span style={{ color: 'red' }}>An error occurred during login. Please try again.</span>}
         {isWaitingForResponse && <span>Waiting for response...</span>}
-        {wasLoginSucessful === false && <span style={{ color: 'red' }}>Login failed. Please try again.</span>}
+        {wasLoginSuccessful === false && <span style={{ color: 'red' }}>Login failed. Please try again.</span>}
         <div style={{ display: 'flex', gap: '0.5em' }}>
           <DialogButton onClick={() => { closeModal?.(); }}>Cancel</DialogButton>
           <DialogButtonPrimary onClick={() => tryLogin()} disabled={ localUsername.length < 1 || localPassword.length < 1 || isWaitingForResponse === true }>

--- a/src/components/PairingModal.tsx
+++ b/src/components/PairingModal.tsx
@@ -12,7 +12,7 @@ export const PairingModal: VFC<{
       }) => {
     const [pin, setPin] = useState("");
     const [clientName, setClientName] = useState("");
-    const [wasPairingSuccessfull, setWasPairingSucessfull ] = useState<boolean | null>(null);
+    const [wasPairingSuccessful, setWasPairingSuccessful ] = useState<boolean | null>(null);
     const [isWaitingForResponse, setIsWaitingForResponse ] = useState(false);
 
     const tryPair = async () => {
@@ -23,12 +23,12 @@ export const PairingModal: VFC<{
         closeModal?.()
       }
       setIsWaitingForResponse(false);
-      setWasPairingSucessfull(success);
+      setWasPairingSuccessful(success);
     }
 
     const handlePINChange = (e: ChangeEvent<HTMLInputElement>) => {
       if (/^\d{0,4}$/.test(e.currentTarget.value)) {
-        setWasPairingSucessfull(null);
+        setWasPairingSuccessful(null);
         setPin(e.currentTarget.value);
       }
     }
@@ -54,7 +54,7 @@ export const PairingModal: VFC<{
             onChange={handlePINChange} />
         </Field>
         {isWaitingForResponse && <span>Waiting for response...</span>}
-        {wasPairingSuccessfull === false && <span style={{ color: 'red' }}>Pairing failed. Please try again.</span>}
+        {wasPairingSuccessful === false && <span style={{ color: 'red' }}>Pairing failed. Please try again.</span>}
         <DialogButton onClick={() => tryPair()} disabled={ pin.length < 4 || clientName.length < 1 || isWaitingForResponse == true }>
           Pair
         </DialogButton>

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { TextField } from "decky-frontend-lib";
 
-// NumericInputProps interface with value and onChange properties
 interface PasswordInputProps {
   style?: React.CSSProperties;
   label?: string;
@@ -12,16 +11,20 @@ interface PasswordInputProps {
 export const PasswordInput = (props: PasswordInputProps): JSX.Element => {
   const { style, label, value, onChange } = props;
 
-  const tfId = Math.trunc(Math.random() * 999_999)
-
-  const doOnChange = (e: any) => {
-    e.target.type = "password"
-    onChange?.(e.target.value)
-  }
-
+  // Mask the input via CSS instead of type="password": Valve's TextField
+  // manages the underlying input's type itself and resets it, so neither
+  // bIsPassword nor forcing input.type sticks (its behavior apparently
+  // changed with some Steam client update). The style prop however is passed
+  // through to the underlying <input>, and -webkit-text-security masks the
+  // rendered characters in CEF/Chromium independently of the input type.
   return (
-    <React.Fragment>
-      <TextField id={`passwordInput-${tfId}`} typeof="password" itemType="password" label={label} style={style} bIsPassword={true} bShowClearAction={(value?.length ?? 0) > 0} value={value} onChange={doOnChange}></TextField>
-    </React.Fragment>
+    <TextField
+      label={label}
+      style={{ ...style, WebkitTextSecurity: "disc" } as React.CSSProperties}
+      bIsPassword={true}
+      bShowClearAction={(value?.length ?? 0) > 0}
+      value={value}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,12 +16,12 @@ import { LOG_TAG } from "./util/constants";
 
 const Content: VFC = () => {
   const HEALTH_CHECK_INTERVAL = 5000;
-  const STATE_UPDATE_INTERVAL = 1000;
 
   // State
   const [isSunshineRunning, setIsSunshineRunning] = useState<boolean>(false);
   const [areCredentialsValid, setAreCredentialsValid] = useState<boolean | null>(null);
-  const [shouldSunshineRun, setShouldSunshineRun] = useState<boolean>(false);
+  // The run state Sunshine is currently transitioning to, or null if no transition is in progress
+  const [pendingRunState, setPendingRunState] = useState<boolean | null>(null);
   const [sunshineCurrentVersion, setSunshineCurrentVersion] = useState<string | null>(null);
   const [sunshineUpdateVersion, setSunshineUpdateVersion] = useState<string | null>(null);
   const [updateCheckTriggeredManually, setUpdateCheckTriggeredManually] = useState<boolean>(false);
@@ -40,84 +40,61 @@ const Content: VFC = () => {
   };
 
   useEffect(() => {
-    const initializeIsSunshineRunning = async () => {
-      const isSunshineRunning = await backend.isSunshineRunning();
-
-      // On startup, the backend will load the lastRunState and start Sunshine if it ran before.
-      // Thus, we check the state of Sunshine and update the local state accordingly.
-      setIsSunshineRunning(isSunshineRunning);
-      setShouldSunshineRun(isSunshineRunning);
+    const initialize = async () => {
+      await updateSunshineState();
       setIsInitializing(false);
     };
 
-    initializeIsSunshineRunning();
+    initialize();
   }, []);
 
   useEffect(() => {
-    const initializeAreCredentialsValid = async () => {
-      const areCredentialsValid = await backend.areCredentialsValid();
-
-      setAreCredentialsValid(areCredentialsValid);
-    };
-
-    initializeAreCredentialsValid();
+    refreshVersionInfo(false);
   }, []);
 
   useEffect(() => {
-    refreshVersionInfo();
-  }, []);
-
-  useEffect(() => {
-    const healthCheck = setInterval(async () => {
-      const hasDesiredState = shouldSunshineRun === isSunshineRunning;
-      if (hasDesiredState) {
-        await updateSunshineState();
-      }
-    }, HEALTH_CHECK_INTERVAL);
-
-    return () => clearInterval(healthCheck);
-  }, []);
-
-  useEffect(() => {
-    // Start or stop Sunshine if wanted
-    const hasDesiredState = shouldSunshineRun === isSunshineRunning;
-    if (hasDesiredState) {
+    // Pause the health check while a transition is in progress;
+    // toggleSunshine updates the state itself when it finishes.
+    if (pendingRunState !== null) {
       return;
     }
 
-    const startStopOperation = async () => {
-      try {
-        shouldSunshineRun ? await backend.startSunshine() : await backend.stopSunshine();
-      } catch (error) {
-        console.error(LOG_TAG, "Failed to start/stop Sunshine:", error);
-        // Reset to the previous state on error
-        setShouldSunshineRun(isSunshineRunning);
+    const healthCheck = setInterval(updateSunshineState, HEALTH_CHECK_INTERVAL);
+
+    return () => clearInterval(healthCheck);
+  }, [pendingRunState]);
+
+  const toggleSunshine = async () => {
+    const shouldRun = !isSunshineRunning;
+    setPendingRunState(shouldRun);
+    try {
+      // The backend call only returns once Sunshine has actually been
+      // started/stopped (or the operation failed or timed out)
+      const success = shouldRun ? await backend.startSunshine() : await backend.stopSunshine();
+      if (!success) {
+        console.error(LOG_TAG, `Failed to ${shouldRun ? "start" : "stop"} Sunshine`);
       }
-    };
+    } catch (error) {
+      console.error(LOG_TAG, "Failed to start/stop Sunshine:", error);
+    } finally {
+      await updateSunshineState();
+      setPendingRunState(null);
+    }
+  };
 
-    startStopOperation();
-
-    // Update state each second till loading is done
-    const interval = setInterval(async () => {
-      const isSunshineRunning = await backend.isSunshineRunning();
-      const hasDesiredState = shouldSunshineRun === isSunshineRunning;
-      hasDesiredState ? clearInterval(interval) : updateSunshineState();
-    }, STATE_UPDATE_INTERVAL);
-
-    // Cleanup interval to avoid memory leaks
-    return () => clearInterval(interval);
-  }, [shouldSunshineRun]);
-
-  const refreshVersionInfo = async () => {
+  const refreshVersionInfo = async (refreshAppstream: boolean) => {
     setIsRefreshingVersionInfo(true);
-    const versionInfo = await backend.getSunshineVersionInfo();
-    setIsRefreshingVersionInfo(false);
-    setSunshineCurrentVersion(versionInfo?.current_version ?? null);
-    setSunshineUpdateVersion(versionInfo?.update_version ?? null);
+    try {
+      const versionInfo = await backend.getSunshineVersionInfo(refreshAppstream);
+      setSunshineCurrentVersion(versionInfo?.current_version ?? null);
+      setSunshineUpdateVersion(versionInfo?.update_version ?? null);
+    } finally {
+      setIsRefreshingVersionInfo(false);
+    }
   };
 
   // Show spinner while Sunshine state is being updated or an update is in progress
-  const isStartingOrStopping = shouldSunshineRun !== isSunshineRunning;
+  const isStartingOrStopping = pendingRunState !== null;
   const isBusy = isInitializing || isStartingOrStopping || isUpdating;
   const statusInfo = (() => {
     if (isInitializing) {
@@ -128,7 +105,7 @@ const Content: VFC = () => {
     }
     if (isStartingOrStopping) {
       return {
-        label: shouldSunshineRun ? "Starting..." : "Stopping...",
+        label: pendingRunState ? "Starting..." : "Stopping...",
         color: "orange",
       };
     }
@@ -164,7 +141,7 @@ const Content: VFC = () => {
           </div>
           <ButtonItem
             disabled={isBusy}
-            onClick={() => setShouldSunshineRun(!isSunshineRunning)}
+            onClick={() => toggleSunshine()}
           >
             {isSunshineRunning ? "Stop Sunshine" : "Start Sunshine"}
           </ButtonItem>
@@ -249,27 +226,30 @@ const Content: VFC = () => {
                   disabled={isStartingOrStopping || isUpdating}
                   onClick={async () => {
                     setIsUpdating(true);
-                    const success = await backend.updateSunshine();
-                    setIsUpdating(false);
-                    if (success) {
-                      setSunshineUpdateVersion(null);
-                      setUpdateCheckTriggeredManually(false);
+                    try {
+                      const success = await backend.updateSunshine();
+                      if (success) {
+                        setSunshineUpdateVersion(null);
+                        setUpdateCheckTriggeredManually(false);
+                      }
+                      updateSunshineState();
+                    } finally {
+                      setIsUpdating(false);
                     }
-                    updateSunshineState();
                   }}
                 >
                   Update
                 </ButtonItem>
               </div>
            : <div style={{ display: "contents" }}>
-                {updateCheckTriggeredManually && sunshineUpdateVersion == null && (
+                {updateCheckTriggeredManually && !isRefreshingVersionInfo && (
                   <span>No update available</span>
                 )}
                 <ButtonItem
                   disabled={isRefreshingVersionInfo}
                   onClick={async () => {
                     setUpdateCheckTriggeredManually(true);
-                    await refreshVersionInfo();
+                    await refreshVersionInfo(true);
                   }}
                 >
                   Check for Sunshine update
@@ -299,10 +279,13 @@ const Content: VFC = () => {
                   onClick={async () => {
                     setIsGettingCredentials(true);
                     setGetCredentialsReturnedValue(null);
-                    const credentials = await backend.getCredentials();
-                    setCredentials(credentials);
-                    setGetCredentialsReturnedValue(credentials != null);
-                    setIsGettingCredentials(false);
+                    try {
+                      const credentials = await backend.getCredentials();
+                      setCredentials(credentials);
+                      setGetCredentialsReturnedValue(credentials != null);
+                    } finally {
+                      setIsGettingCredentials(false);
+                    }
                   }}
                 >
                   Show credentials

--- a/src/util/backend.tsx
+++ b/src/util/backend.tsx
@@ -48,8 +48,11 @@ class Backend {
         return result === true;
     }
 
-    public getSunshineVersionInfo = async (): Promise<SunshineVersionInfo | null> => {
-        const result = await this.call<SunshineVersionInfo | null>("getSunshineVersionInfo");
+    public getSunshineVersionInfo = async (refreshAppstream: boolean): Promise<SunshineVersionInfo | null> => {
+        const result = await this.call<{ refresh_appstream: boolean }, SunshineVersionInfo | null>(
+            "getSunshineVersionInfo",
+            { refresh_appstream: refreshAppstream }
+        );
         return result;
     }
 
@@ -66,7 +69,6 @@ class Backend {
             return null;
         }
         const res = await this.serverAPI.callPluginMethod(method, args as unknown);
-        console.log(LOG_TAG, `Backend call ${method} result`, res);
         if (!res?.success) {
             console.error(LOG_TAG, `Backend method ${method} failed`, res?.result);
             return null;


### PR DESCRIPTION
## Summary

Fixes for the correctness, security and maintainability findings from a full code review. All changes tested on-device (Steam Deck, incl. reboot/autostart).

## Backend (`py_modules/sunshine.py`, `main.py`)

- **HTTP timeout was never applied** — it was set on the `Request` object, where `urllib`'s `OpenerDirector.open()` silently overwrites it. Requests could hang indefinitely if Sunshine's web UI stalled. Now passed via `opener.open(request, timeout=5)`.
- **`UnboundLocalError` in `_isDisplayAvailable`** when `drm_info` output is unparseable — `data` was used before assignment in the except path.
- **`ValueError` parsing `flatpak remote-ls`** when the version column is empty — now parsed defensively.
- **Blocking calls froze the event loop** — subprocess/network calls now run in an executor (`_to_thread`). The appstream refresh is decoupled from the version check so it only runs on an explicit "check for update" (it previously ran on every panel open and stalled all status polling).
- **Process launch** via argument list + `start_new_session=True` instead of a nested `sh -c` shell + `preexec_fn` (unsafe in multithreaded processes).
- **`RequestResult` simplified** to a plain dataclass with `success()`/`failure()` factories (was a frozen dataclass with a throwing `__init__` + `object.__new__` tricks).
- **bwrap privilege escalation (local privesc, deck → root)** — the setuid-root bwrap copy lived in a deck-writable directory (`DECKY_PLUGIN_RUNTIME_DIR`), and `chmod u+s` was applied to whatever was there on every start. Any process running as `deck` could swap the binary and have it executed as root. Now copied fresh from `/usr/bin/bwrap` on every start into a root-owned directory on a suid-capable filesystem (`/var/lib/decky-sunshine`), whose parent chain is root-owned so `deck` cannot swap the file or the directory. Setuid is required (Sunshine needs `CAP_SYS_ADMIN` for KMS/DRM capture), which is why the location must be suid-capable (`/run` and `/tmp` are `nosuid`).

## Frontend (`src/`)

- **Start/stop state machine reworked** — removed the stale-closure health check (deps `[]` but reading state) and the second interval that cleared itself without ever applying the final state. A failed start/stop or an external Sunshine crash now reconciles the UI instead of hanging on "Starting…". Relies on the backend calls only returning once the target state is reached.
- **Busy flags wrapped in `try/finally`** so a rejected backend call can't leave the UI stuck on "Updating…"/"Getting credentials…".
- **Password field masking** via `-webkit-text-security: disc` — Valve's `TextField` (resolved from Steam's webpack bundle) stopped honoring `bIsPassword`/`input type` at some point, so the field rendered as plaintext. This was pre-existing, independent of the other changes.
- **"No update available"** now only shows once the check has finished.
- Typo/redundancy cleanups.

## Not changed (deliberately)

- Initial password is still logged once to the plugin log (intentional — no password-reset UI exists yet; documented workaround).
- `ssl.CERT_NONE` against `https://127.0.0.1` (self-signed Sunshine cert on localhost).
