### PR TITLE
Add a "Show Web UI address" button with a QR code

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ This depends on how you ran Sunshine before.
 ### How do I open Sunshine’s Web UI?<a id="faq-webUi"></a>
 Sunshine’s Web UI is available at `https://<your-deck-ip>:47990` — or `https://localhost:47990` in a browser on the Deck itself. Note the `https://`: browsers default to `http://` and Sunshine does not redirect, so without it the page appears unreachable. Your browser will warn about a self-signed certificate; that is expected, proceed anyway. Log in with the credentials shown by the plugin’s `Show credentials` button.
 
+Changing settings (not just viewing) from another device requires Sunshine’s CSRF protection to allow that address — the plugin takes care of this automatically when it starts Sunshine. If saving settings fails with a CSRF error (e.g. right after the Deck’s IP address changed), stop and start Sunshine once from the plugin.
+
 ### Will you add feature X?
 The goal of this plugin is to simplify setting up Sunshine in Game Mode and pairing Moonlight clients.
 If your idea supports that, feel free to open an issue. Features outside this goal will probably not be implemented, since they take development time and ongoing maintenance.

--- a/main.py
+++ b/main.py
@@ -36,7 +36,13 @@ class Plugin:
 
     async def start_sunshine(self):
         decky.logger.info("Starting sunshine...")
+        starting = not await self.sunshineController.isSunshineRunning_async()
+        added_now = await self._ensure_csrf_allowed_origin()
         res = await self.sunshineController.start_async()
+        if starting and res:
+            self.settingManager.setSetting("csrfRestartPending", False)
+        elif added_now:
+            self.settingManager.setSetting("csrfRestartPending", True)
         if res:
             decky.logger.info("Sunshine started")
             self.settingManager.setSetting("lastRunState", "start")
@@ -104,6 +110,50 @@ class Plugin:
         decky.logger.info(f"Credentials found")
         return credentials
 
+    async def get_web_ui_info(self):
+        """
+        The LAN IP other devices reach the Web UI under (None without a
+        network route) and whether changing settings from that address works:
+        the current LAN origin must be covered by csrf_allowed_origins in
+        sunshine.conf (read live, so entries that were already there - from a
+        user or an earlier run - count), and no config change may be pending
+        that the running instance has not loaded (csrfRestartPending; Sunshine
+        reads its config only at startup). When not ready, the frontend offers
+        the one restart that fixes it.
+        """
+        ip = self.sunshineController.getLanIp()
+        editing_ready = False
+        if ip is not None:
+            origin = f"https://{ip}:{self.sunshineController.WebUiPort}"
+            editing_ready = (
+                await self.sunshineController.isCsrfOriginAllowed_async(origin)
+                and not self.settingManager.getSetting("csrfRestartPending", False)
+            )
+        return {
+            "ip": ip,
+            "editing_ready": editing_ready,
+        }
+
+    async def _ensure_csrf_allowed_origin(self):
+        """
+        Keep the Web UI usable (not just viewable) from other devices: have
+        the controller allow the current LAN origin in Sunshine's config and
+        persist which entry the plugin manages (csrfManagedOrigin), so a later
+        run can replace it after an IP change without touching user-added
+        entries. Must run before Sunshine starts; it reads the config only
+        then.
+        :return: Whether the allowance was missing and added just now. The
+                 caller must translate that into the csrfRestartPending
+                 setting: set it when Sunshine kept running (the instance has
+                 not loaded the new entry), clear it once an actual
+                 (re)start happened.
+        """
+        managed_old = self.settingManager.getSetting("csrfManagedOrigin", "")
+        managed_new, added_now = await self.sunshineController.ensureCsrfAllowedOrigin_async(managed_old)
+        if managed_new != managed_old:
+            self.settingManager.setSetting("csrfManagedOrigin", managed_new)
+        return added_now
+
     async def get_sunshine_version_info(self, refresh_appstream = True):
         versionInfo = await self.sunshineController.getSunshineVersionInfo_async(refresh_appstream)
         if versionInfo:
@@ -121,10 +171,16 @@ class Plugin:
 
     async def update_sunshine(self):
         decky.logger.info("Updating Sunshine...")
+        # The update flow restarts Sunshine, so it picks up the origin ensured
+        # here; on failure the old instance may keep running without it.
+        added_now = await self._ensure_csrf_allowed_origin()
         res = await self.sunshineController.updateSunshine_async()
         if res:
+            self.settingManager.setSetting("csrfRestartPending", False)
             decky.logger.info("Sunshine updated successfully")
         else:
+            if added_now:
+                self.settingManager.setSetting("csrfRestartPending", True)
             decky.logger.info("Couldn't update Sunshine")
         return res
 
@@ -168,7 +224,16 @@ class Plugin:
         lastRunState = self.settingManager.getSetting("lastRunState", "")
         if lastRunState in ("start", ""):
             decky.logger.info("Starting Sunshine")
-            await self.sunshineController.start_async()
+            # Sunshine may have survived a plugin_loader restart; then this is
+            # an ensure-only pass and the running instance keeps enforcing the
+            # allowances from its own start (see _ensure_csrf_allowed_origin).
+            starting = not await self.sunshineController.isSunshineRunning_async()
+            added_now = await self._ensure_csrf_allowed_origin()
+            started = await self.sunshineController.start_async()
+            if starting and started:
+                self.settingManager.setSetting("csrfRestartPending", False)
+            elif added_now:
+                self.settingManager.setSetting("csrfRestartPending", True)
 
         decky.logger.info("Decky Sunshine loaded")
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@decky/api": "^1.1.3",
+    "qrcode.react": "^4.2.0",
     "react-icons": "^5.3.0",
     "tslib": "^2.7.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@decky/api':
         specifier: ^1.1.3
         version: 1.1.3
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.7)
       react-icons:
         specifier: ^5.3.0
         version: 5.7.0(react@19.2.7)
@@ -224,7 +227,6 @@ packages:
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
-    cpu: [x64]
     os: [linux]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
@@ -543,6 +545,11 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -1100,6 +1107,10 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  qrcode.react@4.2.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   queue-microtask@1.2.3: {}
 

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -51,6 +51,9 @@ class RequestResult:
 
 class SunshineController:
     SunshineFlatpakAppId = "dev.lizardbyte.app.Sunshine"
+    # Sunshine runs as root, so its config lives in the root user's home
+    SunshineConfigPath = "/root/.var/app/dev.lizardbyte.app.Sunshine/config/sunshine/sunshine.conf"
+    WebUiPort = 47990
     logger = None
 
     authHeader = ""
@@ -336,6 +339,135 @@ class SunshineController:
                 return False
             self.logger.info("Sunshine was installed successfully.")
             return await self._initSunshine()
+
+    def getLanIp(self) -> str | None:
+        """
+        Best-effort LAN IP of this device, for showing the user a Web UI URL
+        that other devices on the network can reach. Connecting a UDP socket
+        sends no packets; it only makes the kernel pick the source address for
+        the default route (the target is TEST-NET-1, never actually routable).
+        :return: The LAN IP, or None when there is no route (e.g. no network)
+        """
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                s.connect(("192.0.2.1", 80))
+                return s.getsockname()[0]
+        except OSError as e:
+            self.logger.warning(f"Could not determine the LAN IP: {e}")
+            return None
+
+    def lanWebUiOrigin(self) -> str | None:
+        """
+        The origin under which other devices on the network reach the Web UI,
+        or None when the LAN IP cannot be determined.
+        """
+        ip = self.getLanIp()
+        return f"https://{ip}:{self.WebUiPort}" if ip else None
+
+    @staticmethod
+    def _originMatchesAny(origin: str, allowed: list[str]) -> bool:
+        """
+        Whether origin is covered by one of the allowed entries, mirroring
+        Sunshine's own check: exact prefix followed by ':' (port), '/' (path)
+        or the end of the origin - so a port-less entry like
+        https://192.0.2.5 also covers https://192.0.2.5:47990.
+        """
+        for entry in allowed:
+            if origin == entry:
+                return True
+            if origin.startswith(entry) and origin[len(entry)] in ":/":
+                return True
+        return False
+
+    def _readCsrfAllowedOrigins(self) -> tuple[list[str], int | None, list[str]]:
+        """
+        Read sunshine.conf and extract the csrf_allowed_origins option.
+        :return: (all file lines, index of the option's line or None, origins)
+        """
+        lines = []
+        if os.path.exists(self.SunshineConfigPath):
+            with open(self.SunshineConfigPath) as f:
+                lines = f.read().splitlines()
+        for i, line in enumerate(lines):
+            key, separator, value = line.partition("=")
+            if separator and key.strip() == "csrf_allowed_origins":
+                return lines, i, [o.strip() for o in value.split(",") if o.strip()]
+        return lines, None, []
+
+    async def isCsrfOriginAllowed_async(self, origin: str) -> bool:
+        """
+        See isCsrfOriginAllowed.
+        """
+        return await self._to_thread(lambda: self.isCsrfOriginAllowed(origin))
+
+    def isCsrfOriginAllowed(self, origin: str) -> bool:
+        """
+        Whether sunshine.conf currently allows origin for CSRF-protected
+        requests. This is the file's state: a running Sunshine instance only
+        enforces what the file said when the instance started.
+        :return: True if allowed, False if not or the config is unreadable
+        """
+        try:
+            _, _, origins = self._readCsrfAllowedOrigins()
+            return self._originMatchesAny(origin, origins)
+        except OSError as e:
+            self.logger.exception("Could not read csrf_allowed_origins from sunshine.conf", exc_info=e)
+            return False
+
+    async def ensureCsrfAllowedOrigin_async(self, previously_managed: str) -> tuple[str, bool]:
+        """
+        See ensureCsrfAllowedOrigin.
+        """
+        return await self._to_thread(lambda: self.ensureCsrfAllowedOrigin(previously_managed))
+
+    def ensureCsrfAllowedOrigin(self, previously_managed: str) -> tuple[str, bool]:
+        """
+        Make sure csrf_allowed_origins in sunshine.conf covers this device's
+        current LAN origin, so browsers on other devices may use the Web UI's
+        state-changing endpoints (by default Sunshine only allows localhost
+        origins, turning the Web UI read-only from anywhere else). The entry a
+        previous run added (previously_managed) is replaced instead of
+        accumulating stale IPs, while entries the user added are left alone -
+        including a user entry that already covers the origin, in which case
+        nothing is added. Sunshine reads its config at startup, so call this
+        before starting it.
+        :param previously_managed: The origin a previous run added, or ""
+        :return: (managed, added_now): the entry the plugin now owns in the
+                 file ("" if a user entry covers the origin; persist it for
+                 the next run) and whether the origin's allowance was missing
+                 and added just now - meaning an already running instance has
+                 not loaded it. On an unknown IP or errors the file is
+                 unchanged and (previously_managed, False) is returned.
+        """
+        origin = self.lanWebUiOrigin()
+        if not origin:
+            return previously_managed, False
+        try:
+            os.makedirs(os.path.dirname(self.SunshineConfigPath), exist_ok=True)
+            lines, key_index, origins = self._readCsrfAllowedOrigins()
+
+            changed = False
+            if previously_managed and previously_managed != origin and previously_managed in origins:
+                origins.remove(previously_managed)
+                changed = True
+            added_now = not self._originMatchesAny(origin, origins)
+            if added_now:
+                origins.append(origin)
+                changed = True
+
+            if changed:
+                new_line = f"csrf_allowed_origins = {','.join(origins)}"
+                if key_index is None:
+                    lines.append(new_line)
+                else:
+                    lines[key_index] = new_line
+                with open(self.SunshineConfigPath, "w") as f:
+                    f.write("\n".join(lines) + "\n")
+                self.logger.info(f"Allowed the Web UI origin {origin} for CSRF-protected requests in sunshine.conf")
+            return (origin if origin in origins else ""), added_now
+        except OSError as e:
+            self.logger.exception("Could not update csrf_allowed_origins in sunshine.conf", exc_info=e)
+            return previously_managed, False
 
     async def start_async(self) -> bool:
         """

--- a/src/components/WebUiModal.tsx
+++ b/src/components/WebUiModal.tsx
@@ -1,0 +1,124 @@
+import { FC, useEffect, useState } from 'react'
+import { DialogButton, ModalRoot, Spinner } from "@decky/ui";
+import { QRCodeSVG } from "qrcode.react";
+import backend from "../util/backend";
+import type { WebUiInfo } from "../util/types";
+
+const WEB_UI_PORT = 47990;
+
+export const WebUiModal: FC<{
+    closeModal?: () => void;
+}> = ({
+        closeModal,
+      }) => {
+    // undefined = still fetching
+    const [info, setInfo] = useState<WebUiInfo | null | undefined>(undefined);
+    const [isRestarting, setIsRestarting] = useState<boolean>(false);
+    const [credentials, setCredentials] = useState<{username: string, password: string} | null>(null);
+    const [credentialsMissing, setCredentialsMissing] = useState<boolean>(false);
+    const [isGettingCredentials, setIsGettingCredentials] = useState<boolean>(false);
+
+    useEffect(() => {
+      backend.getWebUiInfo().then(setInfo);
+    }, []);
+
+    const url = info?.ip ? `https://${info.ip}:${WEB_UI_PORT}` : null;
+
+    const restartSunshine = async () => {
+      setIsRestarting(true);
+      try {
+        if (await backend.stopSunshine()) {
+          await backend.startSunshine();
+        }
+        // Re-check instead of assuming success; on failure the hint stays
+        setInfo(await backend.getWebUiInfo());
+      } finally {
+        setIsRestarting(false);
+      }
+    };
+
+    const showCredentials = async () => {
+      setIsGettingCredentials(true);
+      try {
+        const result = await backend.getCredentials();
+        setCredentials(result);
+        setCredentialsMissing(result == null);
+      } finally {
+        setIsGettingCredentials(false);
+      }
+    };
+
+    // Revealed only on request (never automatically): the Deck's screen may
+    // be streamed or recorded, so a plaintext password must be deliberate.
+    // Closing the modal hides them again.
+    const credentialsBlock = (
+      <>
+        <span style={{ fontSize: "0.9em", opacity: 0.8 }}>
+          Your browser will warn about the certificate - choose to proceed anyway,
+          then log in with the Web UI credentials.
+        </span>
+        {credentials == null
+          ? <DialogButton disabled={isGettingCredentials} onClick={() => showCredentials()}>
+              {isGettingCredentials
+                ? <Spinner style={{ width: 14, height: 14 }} />
+                : "Show credentials"}
+            </DialogButton>
+          : <span style={{ fontSize: "0.9em", userSelect: "text" }}>
+              Username: <b>{credentials.username}</b><br />
+              Password: <b>{credentials.password}</b>
+            </span>
+        }
+        {credentialsMissing &&
+          <span style={{ color: "red", fontSize: "0.9em" }}>No credentials stored</span>
+        }
+      </>
+    );
+
+    return (
+      <ModalRoot onCancel={closeModal}>
+        {info === undefined &&
+          <div style={{ display: "flex", justifyContent: "center" }}>
+            <Spinner style={{ width: 24, height: 24 }} />
+          </div>
+        }
+        {url &&
+          /* Two columns (QR left, text right) to keep the modal flat enough
+             for all hints to fit on screen at once */
+          <div style={{ display: "flex", alignItems: "center", gap: "1.2em" }}>
+            {/* The white padding keeps the quiet zone scanners need, independent of theme */}
+            <div style={{ background: "#ffffff", padding: "0.8em", lineHeight: 0, borderRadius: "0.4em", flexShrink: 0 }}>
+              <QRCodeSVG value={url} size={140} bgColor="#ffffff" fgColor="#000000" />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: "0.6em" }}>
+              <span>Scan the code or open this address in a browser on another device on the same network:</span>
+              <span style={{ fontWeight: 600, fontSize: "1.1em", userSelect: "text", overflowWrap: "anywhere" }}>{url}</span>
+              {!info?.editing_ready &&
+                <>
+                  <span style={{ color: "orange", fontSize: "0.9em" }}>
+                    Right now the other device can only view: saving changes there
+                    starts working after Sunshine restarts.
+                  </span>
+                  <DialogButton disabled={isRestarting} onClick={() => restartSunshine()}>
+                    {isRestarting
+                      ? <Spinner style={{ width: 14, height: 14 }} />
+                      : "Restart Sunshine now (ends active streams)"}
+                  </DialogButton>
+                </>
+              }
+              {credentialsBlock}
+            </div>
+          </div>
+        }
+        {info !== undefined && !info?.ip &&
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.6em", textAlign: "center" }}>
+            <span style={{ color: "orange" }}>
+              This Deck's network address could not be determined - is it connected to a network?
+              You can find the address under Settings → Internet, then open https://(that address):{WEB_UI_PORT}.
+            </span>
+            {credentialsBlock}
+          </div>
+        }
+        <DialogButton style={{ marginTop: "1em" }} onClick={() => { closeModal?.(); }}>Close</DialogButton>
+      </ModalRoot>
+    );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import backend from "./util/backend";
 
 import { PairingModal } from "./components/PairingModal";
 import { CredentialsModal } from "./components/CredentialsModal";
+import { WebUiModal } from "./components/WebUiModal";
 import { LabelWithInfo } from "./components/LabelWithInfo";
 import { LOG_TAG } from "./util/constants";
 
@@ -297,6 +298,24 @@ const Content: FC = () => {
               </div>
           }
         </div>
+      </PanelSectionRow>
+
+    </PanelSection>
+
+    {/* Web UI: its address/QR and its credentials belong together; Steam's
+        browser hard-blocks Sunshine's self-signed certificate (net error
+        -202, no bypass), so instead of opening the Web UI on the Deck, show
+        its address and a QR code for another device. */}
+    <PanelSection title="Web UI">
+      <PanelSectionRow>
+        <ButtonItem
+          layout="below"
+          bottomSeparator="none"
+          disabled={!isSunshineRunning || isBusy}
+          onClick={() => showModal(<WebUiModal />, window)}
+        >
+          Show Web UI address
+        </ButtonItem>
       </PanelSectionRow>
 
       {/* Credentials Section */}

--- a/src/util/backend.tsx
+++ b/src/util/backend.tsx
@@ -1,5 +1,5 @@
 import { call } from "@decky/api";
-import type { SunshineVersionInfo } from './types';
+import type { SunshineVersionInfo, WebUiInfo } from './types';
 import { LOG_TAG } from "./constants";
 
 class Backend {
@@ -55,6 +55,11 @@ class Backend {
     public updateSunshine = async (): Promise<boolean> => {
         const result = await this.call<[], boolean>("update_sunshine");
         return result === true;
+    }
+
+    public getWebUiInfo = async (): Promise<WebUiInfo | null> => {
+        const result = await this.call<[], WebUiInfo>("get_web_ui_info");
+        return result;
     }
 
     public getForceComposition = async (): Promise<boolean> => {

--- a/src/util/types.tsx
+++ b/src/util/types.tsx
@@ -2,3 +2,8 @@ export interface SunshineVersionInfo {
     current_version: string | null;
     update_version: string | null;
 }
+
+export interface WebUiInfo {
+    ip: string | null;
+    editing_ready: boolean;
+}


### PR DESCRIPTION
Issue #102 showed that reaching Sunshine's Web UI is the actual hurdle for users: it is https-only without a redirect and its address is not discoverable from Game Mode.

Opening it on the Deck itself is not possible: Steam's browser hard-blocks the self-signed certificate (net error -202) with no proceed-anyway option. Instead of a local auth-injecting proxy (new security surface for the least comfortable place to use the Web UI), the new button opens a modal showing the reachable URL `https://<lan-ip>:47990` plus a QR code to scan from another device, where browsers do allow proceeding past the certificate warning. The modal also reveals the Web UI credentials on request — never automatically, since the Deck's screen may be streamed or recorded. The button lives in a new "Web UI" panel section together with the credentials, which belong to that UI.

**CSRF handling:** From another device the Web UI would be view-only — Sunshine's CSRF protection only accepts state-changing requests from localhost origins by default. Before every Sunshine start the plugin therefore ensures `csrf_allowed_origins` in sunshine.conf covers the current LAN origin. This does not weaken the protection: it only allows the Web UI's own address; foreign origins stay blocked. The plugin-managed entry is tracked in the settings and replaced after an IP change; user-added entries are left alone, and a user entry already covering the origin (matched with Sunshine's own prefix-and-boundary semantics, so port-less entries count) means nothing is added at all.

Whether editing from the shown address works is reported from ground truth: the current origin must be covered by the config read live, and no config change may be pending that the running instance has not loaded (Sunshine reads its config only at startup). When not ready, the modal explains the view-only state and offers a restart button that re-checks afterwards.

The backend gains `get_web_ui_info` (LAN IP via the UDP-connect source-address trick — no packets sent, `None` without a route — plus the editing-readiness flag). QR rendering via `qrcode.react` (ISC, no runtime dependencies, bundled by rollup like the existing frontend dependencies).

Verified with a config-merge test and a flow state-machine test (fresh/existing configs, user entries, port-less coverage, IP change, surviving loader restarts, update restarts, failure paths) plus a full on-Deck test pass: QR scan and login from another device, saving settings without CSRF errors, restart hint appearing exactly when editing is really blocked, modal layout with all hints visible, credentials reveal, cold and warm starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)