### PR TITLE
Clean up on uninstall: remove the setuid bwrap copies, stop Sunshine

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ To undo this, disable Force Composite.
 If you manually installed Sunshine before, see [the related FAQ entry](#faq-installedBefore).
 If you changed your Sunshine credentials e.g. from [Sunshine's Web UI](#faq-webUi), enter these credentials.
 
+### How do I completely remove the plugin and Sunshine?<a id="faq-uninstall"></a>
+Uninstalling the plugin from the Decky menu stops Sunshine and cleans up everything the plugin placed outside its own folder. Following the usual convention, the Sunshine flatpak itself and its data (credentials, paired devices, configuration) are kept — a later reinstall of the plugin picks up right where you left off. If you want Sunshine gone too, run:
+```bash
+sudo -i flatpak uninstall --delete-data dev.lizardbyte.app.Sunshine
+```
+Note that `--delete-data` removes all paired devices and settings irrevocably.
+
 ### I want to install a nightly version. How can I do that?
 To install a nightly (or specific) version:
 1. Open the Decky tab and press the cog to open Decky Loader settings.

--- a/main.py
+++ b/main.py
@@ -243,15 +243,19 @@ class Plugin:
     async def _uninstall(self):
         """
         Called by the loader when the plugin is being uninstalled (after
-        _unload). The plugin process can die at any moment from here on (the
-        loader SIGKILLs it at the latest ~5 s after its stop request; on the
-        Deck it was observed dying even earlier), so the work is ordered by
-        cost: first dispatch the detached helper that stops Sunshine and
-        releases the composition override (survives this process, ~2 ms),
-        then remove the setuid bwrap copies. Deliberately no in-process
-        stop_async: it never ran to completion in the field. A running
-        Sunshine keeps its already-exec'd binary, so removing the copy while
-        the helper is still stopping it is safe.
+        _unload). The loader SIGKILLs the plugin process at the latest ~5 s
+        after its stop request, and on the Deck the event loop was observed
+        to stop mid-uninstall: a coroutine parked at an await was never
+        resumed. Hence the body must not contain a single await - without
+        suspension points it runs as one uninterruptible block that needs
+        nothing but a live process (blocking the loop is fine, the plugin
+        is going away) - and the work is ordered by cost: first dispatch
+        the detached helper that stops Sunshine and releases the
+        composition override (survives this process, ~2 ms), then remove
+        the setuid bwrap copies. Deliberately no in-process stop_async: it
+        never ran to completion in the field. A running Sunshine keeps its
+        already-exec'd binary, so removing the copy while the helper is
+        still stopping it is safe.
         """
         decky.logger.info("Uninstalling Decky Sunshine...")
         try:
@@ -261,7 +265,7 @@ class Plugin:
         except Exception as e:
             decky.logger.error(f"Error dispatching the uninstall cleanup: {e}")
         try:
-            await self.sunshineController.removeBwrapCopy_async()
+            self.sunshineController.removeBwrapCopy()
         except Exception as e:
             decky.logger.error(f"Error removing the bwrap copy during uninstall: {e}")
         decky.logger.info("Decky Sunshine uninstall cleanup done")

--- a/main.py
+++ b/main.py
@@ -240,6 +240,32 @@ class Plugin:
     async def _unload(self):
         decky.logger.info("Decky Sunshine unloaded")
 
+    async def _uninstall(self):
+        """
+        Called by the loader when the plugin is being uninstalled (after
+        _unload). The plugin process can die at any moment from here on (the
+        loader SIGKILLs it at the latest ~5 s after its stop request; on the
+        Deck it was observed dying even earlier), so the work is ordered by
+        cost: first dispatch the detached helper that stops Sunshine and
+        releases the composition override (survives this process, ~2 ms),
+        then remove the setuid bwrap copies. Deliberately no in-process
+        stop_async: it never ran to completion in the field. A running
+        Sunshine keeps its already-exec'd binary, so removing the copy while
+        the helper is still stopping it is safe.
+        """
+        decky.logger.info("Uninstalling Decky Sunshine...")
+        try:
+            self.sunshineController.dispatchUninstallCleanup(
+                os.path.join(decky.DECKY_PLUGIN_LOG_DIR, "uninstall-cleanup.log")
+            )
+        except Exception as e:
+            decky.logger.error(f"Error dispatching the uninstall cleanup: {e}")
+        try:
+            await self.sunshineController.removeBwrapCopy_async()
+        except Exception as e:
+            decky.logger.error(f"Error removing the bwrap copy during uninstall: {e}")
+        decky.logger.info("Decky Sunshine uninstall cleanup done")
+
     async def _migration(self):
         decky.migrate_settings(str(Path(decky.DECKY_HOME) / "settings" / "decky-sunshine.json"))
 

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -118,6 +118,10 @@ class SunshineController:
         # /run + /tmp are mounted nosuid, so none of those work. /var/lib is
         # root-owned on a suid-capable ext4 mount, so we use a directory there.
         self.environment_variables["FLATPAK_BWRAP"] = "/var/lib/decky-sunshine/bwrap"
+        # Where plugin versions before the move to /var/lib kept the copy;
+        # removed on uninstall (see removeBwrapCopy)
+        runtime_dir = os.environ.get("DECKY_PLUGIN_RUNTIME_DIR")
+        self.legacyBwrapPath = os.path.join(runtime_dir, "bwrap") if runtime_dir else None
         self.environment_variables["LD_LIBRARY_PATH"] = "/usr/lib/:" + self.environment_variables.get("LD_LIBRARY_PATH", "")
 
     def setCredentials(self, username, password) -> str:
@@ -1222,6 +1226,83 @@ class SunshineController:
         except Exception as e:
             self.logger.exception("An error occurred when checking if bwrap was copied", exc_info=e)
         return False
+
+    def removeBwrapCopy(self) -> bool:
+        """
+        Remove the directory holding the setuid-root bwrap copy. Uninstall
+        counterpart to _copyBwrap: without it a setuid-root binary would
+        survive the plugin's removal.
+        :return: True if the copy is gone afterwards, False otherwise
+        """
+        result = True
+        bwrap_dir = os.path.dirname(self.environment_variables["FLATPAK_BWRAP"])
+        try:
+            if os.path.exists(bwrap_dir):
+                shutil.rmtree(bwrap_dir)
+                self.logger.info(f"Removed the bwrap copy directory {bwrap_dir}")
+        except Exception as e:
+            self.logger.exception(f"An error occurred when removing the bwrap copy directory {bwrap_dir}", exc_info=e)
+            result = False
+        # Plugin versions before the move to /var/lib kept the copy in the
+        # runtime dir; that stale setuid binary must not survive either. Only
+        # the file is ours - the runtime dir itself belongs to the loader.
+        try:
+            if self.legacyBwrapPath and os.path.exists(self.legacyBwrapPath):
+                os.remove(self.legacyBwrapPath)
+                self.logger.info(f"Removed the legacy bwrap copy {self.legacyBwrapPath}")
+        except Exception as e:
+            self.logger.exception(f"An error occurred when removing the legacy bwrap copy {self.legacyBwrapPath}", exc_info=e)
+            result = False
+        return result
+
+    async def removeBwrapCopy_async(self) -> bool:
+        """
+        Async variant of removeBwrapCopy that doesn't block the event loop.
+        """
+        return await self._to_thread(self.removeBwrapCopy)
+
+    def dispatchUninstallCleanup(self, log_path: str) -> bool:
+        """
+        Stop Sunshine and release the composition override from a detached
+        helper process during plugin uninstall. Stopping in-process is not
+        reliable there: the plugin process can die at any moment after the
+        loader's stop request (the loader SIGKILLs it at the latest ~5 s
+        after SIGTERM, and on the Deck it was observed dying even earlier,
+        right after the copy removals). The SIGKILL only hits the plugin
+        process itself (no process-group kill), so a helper in its own
+        session survives and finishes the job. Nothing is left to observe
+        it, so it logs to log_path - the plugin's log directory survives
+        the uninstall.
+        :param log_path: File the helper appends its output to
+        :return: True if the helper was dispatched, False otherwise
+        """
+        script = (
+            f'exec >> {shlex.quote(log_path)} 2>&1\n'
+            'echo "$(date) - uninstall cleanup: stopping Sunshine"\n'
+            f'flatpak kill {self.SunshineFlatpakAppId}\n'
+        )
+        username = self._getSessionUsername()
+        if username:
+            script += (
+                f'{shlex.join(["su", username, "-c"])} "DISPLAY=:0 xprop -root '
+                '-f GAMESCOPE_COMPOSITE_FORCE 32c -set GAMESCOPE_COMPOSITE_FORCE 0"\n'
+            )
+        else:
+            script += 'echo "no session user found - not touching the composition override"\n'
+        script += 'echo "$(date) - uninstall cleanup done"\n'
+        try:
+            # environment_variables (not the inherited env) is required here:
+            # the raw environment of the PyInstaller-packed loader has
+            # LD_LIBRARY_PATH pointing at its bundled libs, against which sh
+            # (= bash) fails to start ("symbol lookup error: ...
+            # rl_trim_arg_from_keyseq" against the bundled libreadline,
+            # observed on the Deck). environment_variables prepends /usr/lib/.
+            subprocess.Popen(["sh", "-c", script], env=self.environment_variables, start_new_session=True)
+        except Exception as e:
+            self.logger.exception("An error occurred when dispatching the uninstall cleanup helper", exc_info=e)
+            return False
+        self.logger.info("Dispatched the detached uninstall cleanup helper")
+        return True
 
     def _isSunshineInstalled(self) -> bool:
         result = self._run_and_capture_stdout(

--- a/py_modules/sunshine.py
+++ b/py_modules/sunshine.py
@@ -1255,20 +1255,14 @@ class SunshineController:
             result = False
         return result
 
-    async def removeBwrapCopy_async(self) -> bool:
-        """
-        Async variant of removeBwrapCopy that doesn't block the event loop.
-        """
-        return await self._to_thread(self.removeBwrapCopy)
-
     def dispatchUninstallCleanup(self, log_path: str) -> bool:
         """
         Stop Sunshine and release the composition override from a detached
         helper process during plugin uninstall. Stopping in-process is not
-        reliable there: the plugin process can die at any moment after the
-        loader's stop request (the loader SIGKILLs it at the latest ~5 s
-        after SIGTERM, and on the Deck it was observed dying even earlier,
-        right after the copy removals). The SIGKILL only hits the plugin
+        reliable there: the loader SIGKILLs the plugin process at the
+        latest ~5 s after SIGTERM, and on the Deck its event loop was
+        observed to stop even earlier, mid-uninstall - anything still
+        needing the loop never ran. The SIGKILL only hits the plugin
         process itself (no process-group kill), so a helper in its own
         session survives and finishes the job. Nothing is left to observe
         it, so it logs to log_path - the plugin's log directory survives


### PR DESCRIPTION
## What

Implements the loader's `_uninstall` hook. On uninstall the plugin now:

1. **Dispatches a detached cleanup helper** (own session, survives the plugin process) that stops Sunshine via `flatpak kill` and releases the `GAMESCOPE_COMPOSITE_FORCE` override as the session user. It logs to `uninstall-cleanup.log` in the plugin's log directory, which survives the uninstall.
2. **Removes the setuid-root bwrap copies**: the directory `/var/lib/decky-sunshine` and the inert legacy copy in the plugin runtime dir (the loader only deletes `plugins/<name>`, so both would otherwise outlive the plugin).

## Why a detached helper, and why `_uninstall` contains no `await`

The loader SIGKILLs the plugin process ~5 s after its stop request. More importantly, on the Deck the plugin's asyncio event loop was observed to stop mid-uninstall: coroutines parked at an `await` were never resumed, which is why an earlier in-process `stop_async` never ran to completion in the field. Two consequences:

- **Stopping Sunshine happens in a detached helper.** The SIGKILL only hits the plugin PID (no process-group kill), so a helper in its own session reliably finishes the job regardless of the plugin process. The helper is spawned with the controller's sanitized `environment_variables` like every other subprocess: the raw environment of the PyInstaller-packed loader points `LD_LIBRARY_PATH` at its bundled libs, which makes `sh` fail on startup against the bundled libreadline (`symbol lookup error: rl_trim_arg_from_keyseq`, observed on the Deck).
- **`_uninstall` itself is written without a single `await`.** Asyncio is cooperative: code between suspension points runs as one uninterruptible block, so a body with no awaits needs nothing but a live process — not a live event loop. The copy removal is therefore a plain synchronous call (blocking the loop is fine, the plugin is going away). A unit test drives the coroutine by hand and asserts it completes without suspending.

## Scope

The Sunshine flatpak and its data (credentials, pairings, configuration) are deliberately **kept**, following convention (flatpak keeps data on uninstall, Decky keeps plugin settings/logs); uninstall→reinstall is common troubleshooting and silently losing pairings would be irreversible. A new README FAQ entry documents the manual one-liner for complete removal.

## Testing

Full test pass on a Steam Deck: uninstall with Sunshine running (copies removed, Sunshine stopped, composition atom released, flatpak + config kept), idempotent second uninstall with nothing running, and reinstall afterwards works with existing credentials/pairings. After the switch to the await-free `_uninstall`, a retest on the Deck showed the previously missing final log line and — for the first time — the loader's own "Uninstalled Decky Sunshine", confirming the loop-stall analysis. Unit tests for the hook and helper exist locally and are planned to land with the test-runner/CI setup separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ibzsh697GWX8wn4zA6E7X